### PR TITLE
HST geometric transform ASDF encoding

### DIFF
--- a/HST/README
+++ b/HST/README
@@ -1,9 +1,0 @@
-## Requirements
-
-This currently depends on the development version of asdf, as well as the jwst 
-and stdatamodels packages. I recommend cloning the repositories and installing 
-manually from:
-    - https://github.com/asdf-format/asdf (follow the install instructions, 
-    including updating the submodules)
-    - https://github.com/spacetelescope/stdatamodels
-    - https://github.com/spacetelescope/jwst.git

--- a/HST/README
+++ b/HST/README
@@ -1,0 +1,9 @@
+## Requirements
+
+This currently depends on the development version of asdf, as well as the jwst 
+and stdatamodels packages. I recommend cloning the repositories and installing 
+manually from:
+    - https://github.com/asdf-format/asdf (follow the install instructions, 
+    including updating the submodules)
+    - https://github.com/spacetelescope/stdatamodels
+    - https://github.com/spacetelescope/jwst.git

--- a/HST/README.rst
+++ b/HST/README.rst
@@ -4,7 +4,6 @@ Requirements
 This currently depends on the development version of asdf, as well as the jwst 
 and stdatamodels packages. I recommend cloning the repositories and installing 
 manually from:
-    - https://github.com/asdf-format/asdf (follow the install instructions, 
-    including updating the submodules)
+    - https://github.com/asdf-format/asdf (follow the install instructions, including updating the submodules)
     - https://github.com/spacetelescope/stdatamodels
     - https://github.com/spacetelescope/jwst.git

--- a/HST/README.rst
+++ b/HST/README.rst
@@ -1,0 +1,10 @@
+Requirements
+------------
+
+This currently depends on the development version of asdf, as well as the jwst 
+and stdatamodels packages. I recommend cloning the repositories and installing 
+manually from:
+    - https://github.com/asdf-format/asdf (follow the install instructions, 
+    including updating the submodules)
+    - https://github.com/spacetelescope/stdatamodels
+    - https://github.com/spacetelescope/jwst.git

--- a/HST/dispersion_models.py
+++ b/HST/dispersion_models.py
@@ -1,0 +1,23 @@
+import numpy as np
+from astropy.modeling.models import custom_model
+
+def create_dispxy_model(e, inverse=False):
+    """Return a custom astropy model defining the dispersion.
+
+    Equations here are specifically for WFC3 IR, taken from GRISMCONF's poly.py
+    file (specifically POLY12 and INVPOLY12). Note that the equations are of
+    the same form for both x and y, differing only in the input coefficient
+    matrix e.
+    """
+    e = np.array(e)
+    print(e)
+
+    @custom_model
+    def disp_model(x, y, t):
+        coeffs = [1, x, y, x**2, x*y, y**2]
+        if inverse:
+            return (d - np.dot(coeffs,e[0,:]))/np.dot(coeffs,e[1,:])
+        else:
+            return np.dot(coeffs,e[0,:]) + t*np.dot(coeffs,e[1,:])
+
+    return disp_model

--- a/HST/dispersion_models.py
+++ b/HST/dispersion_models.py
@@ -37,4 +37,5 @@ class DISPXY_ModelConverter(Converter):
 class DISPXY_Extension():
     extension_uri = "asdf://stsci.edu/grismstuff/extensions/extension-1.0"
     converters = [DISPXY_ModelConverter()]
-    tags = ["asdf://stsci.edu/grismstuff/tags/dispxy_model-1.0"]
+    tags = ["tag:stsci.edu:grismstuff/dispxy_model-1.0.0"]
+    #tags = ["asdf://stsci.edu/grismstuff/tags/dispxy_model-1.0"]

--- a/HST/dispersion_models.py
+++ b/HST/dispersion_models.py
@@ -3,30 +3,11 @@ from astropy.modeling.models import custom_model
 from astropy.modeling import Model, Parameter
 from asdf.extension import Converter
 
-def create_dispxy_model(e, inverse=False):
-    """Return a custom astropy model defining the dispersion.
-
-    Equations here are specifically for WFC3 IR, taken from GRISMCONF's poly.py
-    file (specifically POLY12 and INVPOLY12). Note that the equations are of
-    the same form for both x and y, differing only in the input coefficient
-    matrix e.
-    """
-    e = np.array(e)
-    print(e)
-
-    @custom_model
-    def disp_model(x, y, t):
-        coeffs = [1, x, y, x**2, x*y, y**2]
-        if inverse:
-            return (t - np.dot(coeffs,e[0,:]))/np.dot(coeffs,e[1,:])
-        else:
-            return np.dot(coeffs,e[0,:]) + t*np.dot(coeffs,e[1,:])
-
-    return disp_model
-
 class DISPXY_Model(Model):
     n_inputs = 3
     n_outputs = 1
+    _tag = "tag:stsci.edu:grismstuff/dispxy_model-1.0.0"
+    _name = "DISPXY_Model"
 
     def __init__(self, ematrix, inv=False):
         self.ematrix = np.array(ematrix)
@@ -42,7 +23,7 @@ class DISPXY_Model(Model):
 
 class DISPXY_ModelConverter(Converter):
     tags = ["tag:stsci.edu:grismstuff/dispxy_model-*"]
-    types = ["mypackage.DispxyFunction"]
+    types = ["dispersion_models.DISPXY_Model"]
 
     def to_yaml_tree(self, obj, tags, ctx):
         # ASDF will know how to turn the nested lists into yaml properly

--- a/HST/dispersion_models.py
+++ b/HST/dispersion_models.py
@@ -9,17 +9,18 @@ class DISPXY_Model(Model):
     _tag = "tag:stsci.edu:grismstuff/dispxy_model-1.0.0"
     _name = "DISPXY_Model"
 
-    def __init__(self, ematrix, inv=False):
+    def __init__(self, ematrix, offset, inv=False):
         self.ematrix = np.array(ematrix)
         self.inv = inv
 
+    # Note that in the inverse case, input "t" here is actually dx or dy
     def evaluate(self, x, y, t):
         e = self.ematrix
         coeffs = np.array([1, x, y, x**2, x*y, y**2])
         if self.inv:
-            return (t - np.dot(coeffs, e[0,:]))/np.dot(coeffs, e[1,:])
+            return (t + offset - np.dot(coeffs, e[0,:]))/np.dot(coeffs, e[1,:])
         else:
-            return np.dot(coeffs, e[0,:]) + t*np.dot(coeffs, e[1,:])
+            return np.dot(coeffs, e[0,:]) + t*np.dot(coeffs, e[1,:]) - offset
 
 class DISPXY_ModelConverter(Converter):
     tags = ["tag:stsci.edu:grismstuff/dispxy_model-*"]

--- a/HST/dispersion_models.py
+++ b/HST/dispersion_models.py
@@ -16,7 +16,7 @@ def create_dispxy_model(e, inverse=False):
     def disp_model(x, y, t):
         coeffs = [1, x, y, x**2, x*y, y**2]
         if inverse:
-            return (d - np.dot(coeffs,e[0,:]))/np.dot(coeffs,e[1,:])
+            return (t - np.dot(coeffs,e[0,:]))/np.dot(coeffs,e[1,:])
         else:
             return np.dot(coeffs,e[0,:]) + t*np.dot(coeffs,e[1,:])
 

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -1,0 +1,592 @@
+
+import re
+import datetime
+import numpy as np
+
+from asdf.tags.core import Software, HistoryEntry
+
+from astropy import units as u
+from astropy.modeling.models import Polynomial1D, custom_model
+
+from jwst.datamodels import NIRCAMGrismModel
+from jwst.datamodels import wcs_ref_models
+
+def create_dispx_model(e):
+    e = np.array(e)
+    print(e)
+
+    @custom_model
+    def dispx_model(x, y, t):
+        """This is POLY12 from grismconf poly.py"""
+        return e[0,0] + x*e[0,1] + y*e[0,2] + x**2*e[0,3] + x*y*e[0,4] + y**2*e[0,5] + t*(e[1,0] + x*e[1,1] + y*e[1,2] + x**2*e[1,3] + x*y*e[1,4] + y**2*e[1,5])
+
+    return dispx_model
+
+def common_reference_file_keywords(reftype=None,
+                                   title=None,
+                                   description=None,
+                                   exp_type=None,
+                                   author="STScI",
+                                   useafter="2014-01-01T00:00:00",
+                                   module=None,
+                                   fname=None,
+                                   pupil=None, **kwargs):
+    """
+    exp_type can be also "N/A", or "ANY".
+    """
+    if exp_type is None:
+        raise ValueError("exp_type not set")
+    if reftype is None:
+        raise ValueError("Expected reftype value")
+
+    ref_file_common_keywords = {
+        "author": author,
+        "description": description,
+        "exposure": {"type": exp_type},
+        "instrument": {"name": "NIRCAM"},
+        "pedigree": "ground",
+        "reftype": reftype,
+        "telescope": "JWST",
+        "title": title,
+        "useafter": useafter,
+        }
+
+    if fname is not None:
+        ref_file_common_keywords["instrument"]["filter"] = fname
+    if pupil is not None:
+        ref_file_common_keywords["instrument"]["pupil"] = pupil
+    if module is not None:
+        ref_file_common_keywords["instrument"]["module"] = module
+
+    ref_file_common_keywords.update(kwargs)
+    return ref_file_common_keywords
+
+
+def create_grism_specwcs(conffile="",
+                         pupil=None,
+                         module=None,
+                         author="STScI",
+                         history="",
+                         outname=None):
+    """
+    Create an asdf reference file to hold Grism C (column) or Grism R (rows)
+    configuration information, no sensativity information is included
+
+    Note: The orders are named alphabetically, i.e. Order A, Order B
+    There are also sensativity fits files which are tables of wavelength,
+    sensativity, and error. These are specified in the conffile but will
+    not be read in and saved in the output reference file for now.
+    It's possible they may be included in the future, either here or as
+    a separate reference files. Their use here would be to help define the
+    min and max wavelengths which set the extent of the dispersed trace on
+    the grism image. Convolving the sensitiviy file with the filter throughput
+    allows one to calculate the wavelength of minimum throughput which defines
+    the edges of the trace.
+
+    direct_filter is not specified because it assumes that the wedge
+    information (wx,wy) is included in the conf file in one of the key-value
+    pairs, where the key includes the beam designation
+
+     this reference file also contains the polynomial model which is
+     appropriate for the coefficients which are listed.
+     wavelength = DISPL(order,x0,y0,t)
+     dx = DISPX(order,x0,y0,t)
+     dy = DISPY(order,x0,y0,t)
+
+     t = INVDISPX(order,x0,y0,dx)
+     t = INVDISPY(order,x0,y0,dy)
+     t = INVDISL(order,x0,y0, wavelength)
+
+
+
+    Parameters
+    ----------
+    conffile : str
+        The text file with configuration information, formatted as aXe expects
+    pupil : str
+        Name of the grism the conffile corresponds to
+        Taken from the conffile name if not specified
+    module : str
+        Name of the Nircam module
+        Taken from the conffile name if not specified
+    author : str
+        The name of the author
+    history : str
+        A comment about the refrence file to be saved with the meta information
+    outname : str
+        Output name for the reference file
+
+    Returns
+    -------
+    fasdf : asdf.AsdfFile(jwst.datamodels.NIRCAMGrismModel)
+
+    """
+    if outname is None:
+        outname = "nircam_wfss_specwcs.asdf"
+    if not history:
+        history = "Created from {0:s}".format(conffile)
+
+    # if pupil is none get from filename like NIRCAM_modB_R.conf
+    if pupil is None:
+        pupil = "GRISM" + conffile.split(".")[0][-1]
+    # if module is none get from filename
+    if module is None:
+        module = conffile.split(".")[0][-3]
+    print("Pupil is {}".format(pupil))
+
+    ref_kw = common_reference_file_keywords(reftype="specwcs",
+                                            title="NIRCAM Grism Parameters",
+                                            description="{0:s} dispersion models".format(pupil),
+                                            exp_type="NRC_WFSS",
+                                            author=author,
+                                            model_type="NIRCAMGrismModel",
+                                            module=module,
+                                            pupil=pupil,
+                                            filename=outname,
+                                            )
+
+    # get all the key-value pairs from the input file
+    conf = dict_from_file(conffile)
+    beamdict = split_order_info(conf)
+
+    # beam = re.compile('^(?:[+\-]){0,1}[a-zA-Z0-9]{0,1}$')  # match beam only
+    # read in the sensitivity tables to save their content
+    # they currently have names like this: NIRCam.A.1st.sensitivity.fits
+    # translated as inst.beam/order.param
+    temp = dict()
+    etoken = re.compile("^[a-zA-Z]*_(?:[+\-]){1,1}[1,2]{1,1}")  # find beam key
+    for b, bdict in beamdict.items():
+            temp[b] = dict()
+
+    # add the new beam information to beamdict and remove spurious beam info
+    for k in temp:
+        for kk in temp[k]:
+            if etoken.match(kk):
+                kk = kk.replace("_{}".format(k), "")
+            beamdict[k][kk] = temp[k][kk]
+
+    # for NIRCAM, the R and C grism coefficients contain zeros where
+    # the dispersion is in the opposite direction. Meaning, the GRISMR,
+    # which disperses along ROWS has coefficients of zero in the y models
+    # and vice versa.
+    #
+    # There are separate reference files for each grism. Depending on the grism
+    # dispersion direction you either want to use the dx from source center or
+    # the dy from source center in the inverse dispersion relationship which is
+    # used to calculate the t value needed to calculate the wavelength at that
+    # pixel.
+    # The model creation here takes all of this into account by looking at the
+    # GRISM[R/C] the file is used for and creating a reference model with the
+    # appropriate dispersion direction in use. This eliminates having to decide
+    # which direction to calculatethe dispersion from given the input x,y
+    # pixel in the dispersed image.
+    orders = beamdict.keys()
+
+    # dispersion models valid per order and direction saved to reference file
+    # Forward
+    invdispl = []
+    invdispx = []
+    invdispy = []
+    # Backward
+    displ = []
+    dispx = []
+    dispy = []
+
+    for order in orders:
+        # convert the displ wavelengths to microns if the input
+        # file is still in angstroms
+        l0 = beamdict[order]['DISPL'][0] / 10000.
+        l1 = beamdict[order]['DISPL'][1] / 10000.
+
+        # create polynomials using the coefficients of each order
+
+        # This holds the wavelength lookup coeffs
+        # This model is  INVDISPL for backward and returns t
+        # This model should be DISPL for forward and returns wavelength
+        if l1 == 0:
+            lmodel = Polynomial1D(1, c0=0, c1=0)
+        else:
+            lmodel = Polynomial1D(1, c0=-l0/l1, c1=1./l1)
+        invdispl.append(lmodel)
+        lmodel = Polynomial1D(1, c0=l0, c1=l1)
+        displ.append(lmodel)
+
+        # This holds the x coefficients, for the R grism this model is the
+        # the INVDISPX returning t, for the C grism this model is the DISPX
+        e = beamdict[order]['DISPX']
+        xmodel = create_dispx_model(e)
+        dispx.append(xmodel)
+        print(dispx)
+        if x1 == 0:
+            xmodel = Polynomial1D(1, c0=0, c1=0)
+        else:
+            xmodel = Polynomial1D(1, c0=-x0/x1, c1=1./x1)
+        invdispx.append(xmodel)
+
+        # This holds the y coefficients, for the C grism, this model is
+        # the INVDISPY, returning t, for the R grism, this model is the DISPY
+        y0, y1 = beamdict[order]['DISPY']
+        ymodel = Polynomial1D(1, c0=y0, c1=y1)
+        dispy.append(ymodel)
+        if y1 == 0:
+            ymodel = Polynomial1D(1, c0=0, c1=0)
+        else:
+            x0, x1 = beamdict[order]['DISPX'][0:2]
+            ymodel = Polynomial1D(1, c0=-y0/y1, c1=1./y1)
+        invdispy.append(ymodel)
+
+    # change the orders into translatable integers
+    # so that we can look up the order with the proper index
+    oo = [int(o) for o in beamdict]
+
+    ref = NIRCAMGrismModel()
+    ref.meta.update(ref_kw)
+    # This reference file is good for NRC_WFSS and TSGRISM modes
+    ref.meta.exposure.p_exptype = "NRC_WFSS|NRC_TSGRISM"
+    ref.meta.input_units = u.micron
+    ref.meta.output_units = u.micron
+    ref.displ = displ
+    ref.dispx = dispx
+    ref.dispy = dispy
+    ref.invdispx = invdispx
+    ref.invdispy = invdispy
+    ref.invdispl = invdispl
+    ref.order = oo
+    history = HistoryEntry({'description': history,
+                            'time': datetime.datetime.utcnow()})
+    software = Software({'name': 'nircam_reftools.py',
+                         'author': author,
+                         'homepage': 'https://github.com/spacetelescope/jwreftools',
+                         'version': '0.7.1'})
+    history['software'] = software
+    ref.history = [history]
+    ref.to_asdf(outname)
+    ref.validate()
+
+
+def create_tsgrism_wavelengthrange(outname="nircam_tsgrism_wavelengthrange.asdf",
+                                   history="Ground NIRCAM TSGrism wavelengthrange",
+                                   author="STScI",
+                                   wavelengthrange=None,
+                                   extract_orders=None):
+    """Create a wavelengthrange reference file for NIRCAM TSGRISM mode.
+
+    Parameters
+    ----------
+    outname: str
+        The output name of the file
+    history: str
+        History information about it's creation
+    author: str
+        Person or entity making the file
+    wavelengthrange: list(tuples)
+        A list of tuples that set the order, filter, and
+        wavelength range min and max
+    extract_orders: list[list]
+        A list of lists that specify
+
+    """
+    ref_kw = common_reference_file_keywords(reftype="wavelengthrange",
+                                            title="NIRCAM TSGRISM reference file",
+                                            description="NIRCAM Grism-Filter Wavelength Ranges",
+                                            exp_type="NRC_TSGRISM",
+                                            author=author,
+                                            pupil="ANY",
+                                            model_type="WavelengthrangeModel",
+                                            filename=outname,
+                                            )
+
+    if wavelengthrange is None:
+        # This is a list of tuples that specify the
+        # order, filter, wave min, wave max
+        wavelengthrange = [(1, 'F277W', 2.500411072, 3.807062006),
+                           (1, 'F322W2', 2.5011293930000003, 4.215842089),
+                           (1, 'F356W', 3.001085025, 4.302320901),
+                           (1, 'F444W', 3.696969216, 4.899565197),
+                           (2, 'F277W', 2.500411072, 3.2642254050000004),
+                           (2, 'F322W2', 2.5011293930000003, 4.136119434),
+                           (2, 'F356W', 2.529505253, 4.133416971),
+                           (2, 'F444W', 2.5011293930000003, 4.899565197),
+                           ]
+
+    # array of integers of unique orders
+    orders = sorted(set((x[0] for x in wavelengthrange)))
+    filters = sorted(set((x[1] for x in wavelengthrange)))
+
+    # Nircam has not specified any limitation on the orders
+    # that should be extracted by default yet so all are
+    # included.
+    if extract_orders is None:
+        extract_orders = [('F277W', [1]),
+                          ('F322W2', [1]),
+                          ('F356W', [1]),
+                          ('F444W', [1]),
+                          ]
+
+    ref = wcs_ref_models.WavelengthrangeModel()
+    ref.meta.update(ref_kw)
+    ref.meta.exposure.p_exptype = "NRC_TSGRISM"
+    ref.meta.input_units = u.micron
+    ref.meta.output_units = u.micron
+    ref.wavelengthrange = wavelengthrange
+    ref.extract_orders = extract_orders
+    ref.order = orders
+    ref.waverange_selector = filters
+
+    history = HistoryEntry({'description': history,
+                            'time': datetime.datetime.utcnow()})
+    software = Software({'name': 'nircam_reftools.py',
+                         'author': author,
+                         'homepage': 'https://github.com/spacetelescope/jwreftools',
+                         'version': '0.7.1'})
+    history['software'] = software
+    ref.history = [history]
+    ref.validate()
+    ref.to_asdf(outname)
+
+
+def create_wfss_wavelengthrange(outname="nircam_wfss_wavelengthrange.asdf",
+                                history="Ground NIRCAM Grism wavelengthrange",
+                                author="STScI",
+                                wavelengthrange=None,
+                                extract_orders=None):
+    """Create a wavelengthrange reference file for NIRCAM.
+
+    Parameters
+    ----------
+    outname: str
+        The output name of the file
+    history: str
+        History information about it's creation
+    author: str
+        Person or entity making the file
+    wavelengthrange: list(tuples)
+        A list of tuples that set the order, filter, and
+        wavelength range min and max
+    extract_orders: list[list]
+        A list of lists that specify
+
+    """
+    ref_kw = common_reference_file_keywords(reftype="wavelengthrange",
+                                            title="NIRCAM WFSS reference file",
+                                            description="NIRCAM Grism-Filter Wavelength Ranges",
+                                            exp_type="NRC_WFSS",
+                                            author=author,
+                                            pupil="ANY",
+                                            model_type="WavelengthrangeModel",
+                                            filename=outname,
+                                            )
+
+    if wavelengthrange is None:
+        # This is a list of tuples that specify the
+        # order, filter, wave min, wave max
+        wavelengthrange = [(1, 'F250M', 2.500411072, 4.800260833),
+                           (1, 'F277W', 2.500411072, 3.807062006),
+                           (1, 'F300M', 2.684896869, 4.025318456),
+                           (1, 'F322W2', 2.5011293930000003, 4.215842089),
+                           (1, 'F335M', 3.01459734, 4.260432726),
+                           (1, 'F356W', 3.001085025, 4.302320901),
+                           (1, 'F360M', 3.178096344, 4.00099629),
+                           (1, 'F410M', 3.6267051809999997, 4.5644598),
+                           (1, 'F430M', 4.04828939, 4.511761774),
+                           (1, 'F444W', 3.696969216, 4.899565197),
+                           (1, 'F460M', 3.103778615, 4.881999188),
+                           (1, 'F480M', 4.5158154679999996, 4.899565197),
+                           (2, 'F250M', 2.500411072, 2.667345336),
+                           (2, 'F277W', 2.500411072, 3.2642254050000004),
+                           (2, 'F300M', 2.6659796289999997, 3.2997071729999994),
+                           (2, 'F322W2', 2.5011293930000003, 4.136119434),
+                           (2, 'F335M', 2.54572003, 3.6780519760000003),
+                           (2, 'F356W', 2.529505253, 4.133416971),
+                           (2, 'F360M', 2.557881113, 4.83740855),
+                           (2, 'F410M', 2.5186954019999996, 4.759037127),
+                           (2, 'F430M', 2.5362614100000003, 4.541488865),
+                           (2, 'F444W', 2.5011293930000003, 4.899565197),
+                           (2, 'F460M', 2.575447122, 4.883350419),
+                           (2, 'F480M', 2.549773725, 4.899565197),
+                           ]
+    # array of integers of unique orders
+    orders = sorted(set((x[0] for x in wavelengthrange)))
+    filters = sorted(set((x[1] for x in wavelengthrange)))
+
+    # Nircam has not specified any limitation on the orders
+    # that should be extracted by default yet so all are
+    # included.
+    if extract_orders is None:
+        extract_orders = []
+        for f in filters:
+            extract_orders.append([f, orders])
+
+    ref = wcs_ref_models.WavelengthrangeModel()
+    ref.meta.update(ref_kw)
+    ref.meta.exposure.p_exptype = "NRC_WFSS"
+    ref.meta.input_units = u.micron
+    ref.meta.output_units = u.micron
+    ref.wavelengthrange = wavelengthrange
+    ref.extract_orders = extract_orders
+    ref.order = orders
+    ref.waverange_selector = filters
+
+    history = HistoryEntry({'description': history,
+                            'time': datetime.datetime.utcnow()})
+    software = Software({'name': 'nircam_reftools.py',
+                         'author': author,
+                         'homepage': 'https://github.com/spacetelescope/jwreftools',
+                         'version': '0.7.1'})
+    history['software'] = software
+    ref.history = [history]
+    ref.validate()
+    ref.to_asdf(outname)
+
+
+def split_order_info(keydict):
+    """
+    Designed to take as input the dictionary created by dict_from_file and for
+    nircam, split out and accumulate the keys for each beam/order.
+    The keys must have the beam in their string, the spurious beam designation
+    is removed from the returned dictionary. Keywords with the same first name
+    in the underscore separated string followed by a number are assumed to be
+    ranges
+
+
+    Parameters
+    ----------
+    keydict : dictionary
+        Dictionary of key value pairs
+
+    Returns
+    -------
+    dictionary of beams, where each beam has a dictionary of key-value pairs
+    Any key pairs which are not associated with a beam get a separate entry
+    """
+
+    if not isinstance(keydict, dict):
+        raise ValueError("Expected an input dictionary")
+
+    # has beam name fits token
+    token = re.compile('^[a-zA-Z]*_(?:[+\-]){0,1}[a-zA-Z0-9]{0,1}_*')
+    rangekey = re.compile('^[a-zA-Z]*_[0-1]{1,1}$')
+    rdict = dict()  # return dictionary
+    beams = list()
+
+    # prefetch number of Beams, beam is the second string
+    for key in keydict:
+        # Reject WEDGE keys that would otherwise match beam regex
+        if key[0:5] == "WEDGE":
+            continue
+        if token.match(key):
+            b = key.split("_")[1].upper()
+            if b not in beams:
+               beams.append(b)
+    for b in beams:
+        rdict[b] = dict()
+
+    #  assumes that keys are sep with underscore and beam is in second section
+    for key in keydict:
+        # Again, reject WEDGE keys
+        if key[0:5] == "WEDGE":
+            continue
+        if token.match(key):
+            b = key.split("_")[1].upper()
+            newkey = key.replace("_{}".format(b), "")
+            rdict[b][newkey] = keydict[key]
+
+    # look for range variables to make them into tuples
+    for b, d in rdict.items():
+        keys = d.keys()
+        rkeys = []
+        odict = {}
+        for k in keys:
+            if rangekey.match(k):
+                rkeys.append(k)
+        for k in rkeys:
+            mlist = [m for m in rkeys if k.split("_")[0] in m]
+            root = mlist[0].split("_")[0]
+            if root not in odict:
+                for mk in mlist:
+                    if eval(mk[-1]) == 0:
+                        zero = d[mk]
+                    elif eval(mk[-1]) == 1:
+                        one = d[mk]
+                    else:
+                        raise ValueError("Unexpected range variable {}"
+                                         .format(mk))
+                odict[root] = (zero, one)
+        # combine the dictionaries and remove the old keys
+        d.update(odict)
+        for k in rkeys:
+            del d[k]
+
+    return rdict
+
+
+def dict_from_file(filename):
+    """Read in a file and return a named tuple of the key value pairs.
+
+    This is a generic read for a text file with the line following format:
+
+    keyword<token>value
+
+    Where keyword should start with a character, not a number
+    Non-alphabetic starting characters are ignored
+    <token> can be space or comma
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to interpret
+
+    Examples
+    --------
+    dict_from_file('NIRCAM_C.conf')
+
+    Returns
+    -------
+    dictionary of deciphered keys and values
+
+    """
+    token = '\s+|(?<!\d)[,](?!\d)'
+    letters = re.compile("(^[a-zA-Z])")  # starts with a letter
+    numbers = re.compile("(^(?:[+\-])?(?:\d*)(?:\.)?(?:\d*)?(?:[eE][+\-]?\d*$)?)")
+    empty = re.compile("(^\s*$)")  # is a blank line
+
+    print("\nReading {0:s}  ...".format(filename))
+    with open(filename, 'r') as fh:
+        lines = fh.readlines()
+    content = dict()
+    for line in lines:
+        value = None
+        key = None
+        if not empty.match(line):
+            if letters.match(line):
+                pair = re.split(token, line.strip())
+                if len(pair) == 2:  # key and value exist
+                    key = pair[0]  # first item is the key
+                    val = pair[1]  # second item is the value
+                    if letters.match(val):
+                        value = val
+                    if numbers.fullmatch(val):
+                        value = eval(val)
+                if len(pair) == 3:  # key min max exist
+                    key = pair[0]
+                    val1, val2 = pair[1:]
+                    if numbers.fullmatch(val1) and numbers.fullmatch(val2):
+                        value = (eval(val1), eval(val2))
+                    else:
+                        raise ValueError("Min/max values expected for {0}"
+                                         .format(key))
+                elif len(pair) > 3: # Key and many values exist (DISPX and DISPY)
+                    key = pair[0]
+                    value = []
+                    for i in range(1, len(pair)):
+                        value.append(eval(pair[i]))
+                    value = tuple(value)
+
+        # ignore the filter file pointings and the sensitivity files these are
+        # used for simulation
+        if key and (value is not None):
+            if (("FILTER" not in key) and ("SENSITIVITY" not in key)):
+                content[key] = value
+                print("Setting {0:s} = {1}".format(key, value))
+
+    return content

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -211,7 +211,7 @@ def create_grism_specwcs(conffile="",
         xmodel = create_dispxy_model(e)
         dispx.append(xmodel)
         print(dispx)
-        inv_xmodel = create_dispx_model(e, inverse=True)
+        inv_xmodel = create_dispxy_model(e, inverse=True)
         invdispx.append(inv_xmodel)
 
         # This holds the y coefficients, for the C grism, this model is
@@ -475,7 +475,7 @@ def split_order_info(keydict):
             continue
         if token.match(key):
             b = key.split("_")[1].upper()
-            newkey = key.replace("_{}".format(b), "")
+            newkey = key.replace("_{}_".format(b), "_")
             rdict[b][newkey] = keydict[key]
 
     # look for range variables to make them into tuples

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -17,7 +17,8 @@ def create_dispx_model(e):
 
     @custom_model
     def dispx_model(x, y, t):
-        """This is POLY12 from grismconf poly.py"""
+        """This is POLY12 from GRISMCONF's poly.py
+        see https://github.com/npirzkal/GRISMCONF/blob/master/grismconf/poly.py"""
         return e[0,0] + x*e[0,1] + y*e[0,2] + x**2*e[0,3] + x*y*e[0,4] + y**2*e[0,5] + t*(e[1,0] + x*e[1,1] + y*e[1,2] + x**2*e[1,3] + x*y*e[1,4] + y**2*e[1,5])
 
     return dispx_model
@@ -69,6 +70,11 @@ def create_grism_specwcs(conffile="",
                          history="",
                          outname=None):
     """
+    Note: This code is shamelessly stolen from the jwreftools package
+    (see https://github.com/spacetelescope/jwreftools/) and adapted for use
+    on HST GRISMCONF files. The docstrings and comments have not yet been
+    updated accordingly.
+
     Create an asdf reference file to hold Grism C (column) or Grism R (rows)
     configuration information, no sensativity information is included
 

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -8,7 +8,8 @@ from asdf.tags.core import Software, HistoryEntry
 from astropy import units as u
 from astropy.modeling.models import Polynomial1D
 
-from jwst.datamodels import NIRCAMGrismModel
+#from jwst.datamodels import NIRCAMGrismModel
+from wcs_ref_model import WFC3IRGrismModel
 from jwst.datamodels import wcs_ref_models
 from dispersion_models import DISPXY_Model, DISPXY_Extension
 
@@ -134,7 +135,7 @@ def create_grism_specwcs(conffile="",
                                             description="{0:s} dispersion models".format(pupil),
                                             exp_type="WFC3_IR",
                                             author=author,
-                                            model_type="HSTIRGrismModel",
+                                            model_type="NIRCAMGrismModel",
                                             module=module,
                                             pupil=pupil,
                                             filename=outname,
@@ -211,8 +212,7 @@ def create_grism_specwcs(conffile="",
         e = beamdict[order]['DISPX']
         xmodel = DISPXY_Model(e)
         dispx.append(xmodel)
-        print(dispx)
-        inv_xmodel = DISPXY_Model(e, inverse=True)
+        inv_xmodel = DISPXY_Model(e, inv=True)
         invdispx.append(inv_xmodel)
 
         # This holds the y coefficients, for the C grism, this model is
@@ -220,7 +220,7 @@ def create_grism_specwcs(conffile="",
         e = beamdict[order]['DISPY']
         ymodel = DISPXY_Model(e)
         dispy.append(ymodel)
-        inv_ymodel = DISPXY_Model(e, inverse=True)
+        inv_ymodel = DISPXY_Model(e, inv=True)
         invdispy.append(ymodel)
 
     # change the orders into translatable integers
@@ -230,7 +230,8 @@ def create_grism_specwcs(conffile="",
     # We need to register the converter for the DISPXY_Model class with asdf
     asdf.get_config().add_extension(DISPXY_Extension())
 
-    ref = HSTIRGrismModel()
+    ref = WFC3IRGrismModel()
+    #ref = NIRCAMGrismModel()
     ref.meta.update(ref_kw)
     # This reference file is good for NRC_WFSS and TSGRISM modes
     ref.meta.exposure.p_exptype = "NRC_WFSS|NRC_TSGRISM"

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -146,6 +146,8 @@ def create_grism_specwcs(conffile="",
     else:
         wx, wy = 0, 0
 
+    beamdict.pop("WEDGE")
+
     # beam = re.compile('^(?:[+\-]){0,1}[a-zA-Z0-9]{0,1}$')  # match beam only
     # read in the sensitivity tables to save their content
     # they currently have names like this: NIRCam.A.1st.sensitivity.fits

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -211,17 +211,17 @@ def create_grism_specwcs(conffile="",
         # This holds the x coefficients, for the R grism this model is the
         # the INVDISPX returning t, for the C grism this model is the DISPX
         e = beamdict[order]['DISPX']
-        xmodel = DISPXY_Model(e)
+        xmodel = DISPXY_Model(e, wx)
         dispx.append(xmodel)
-        inv_xmodel = DISPXY_Model(e, inv=True)
+        inv_xmodel = DISPXY_Model(e, wx, inv=True)
         invdispx.append(inv_xmodel)
 
         # This holds the y coefficients, for the C grism, this model is
         # the INVDISPY, returning t, for the R grism, this model is the DISPY
         e = beamdict[order]['DISPY']
-        ymodel = DISPXY_Model(e)
+        ymodel = DISPXY_Model(e, wy)
         dispy.append(ymodel)
-        inv_ymodel = DISPXY_Model(e, inv=True)
+        inv_ymodel = DISPXY_Model(e, wy, inv=True)
         invdispy.append(ymodel)
 
     # change the orders into translatable integers

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -34,7 +34,7 @@ def common_reference_file_keywords(reftype=None,
         "author": author,
         "description": description,
         "exposure": {"type": exp_type},
-        "instrument": {"name": "NIRCAM"},
+        "instrument": {"name": "WFC3"},
         "pedigree": "ground",
         "reftype": reftype,
         "telescope": "HST",
@@ -114,11 +114,11 @@ def create_grism_specwcs(conffile="",
 
     Returns
     -------
-    fasdf : asdf.AsdfFile(jwst.datamodels.NIRCAMGrismModel)
+    fasdf : asdf.AsdfFile(WFC3IRGrismModel)
 
     """
     if outname is None:
-        outname = "nircam_wfss_specwcs.asdf"
+        outname = "wfc3_ir_specwcs.asdf"
     if not history:
         history = "Created from {0:s}".format(conffile)
 
@@ -135,7 +135,7 @@ def create_grism_specwcs(conffile="",
                                             description="{0:s} dispersion models".format(pupil),
                                             exp_type="WFC3_IR",
                                             author=author,
-                                            model_type="NIRCAMGrismModel",
+                                            model_type="WFC3IRGrismModel",
                                             module=module,
                                             pupil=pupil,
                                             filename=outname,
@@ -231,7 +231,6 @@ def create_grism_specwcs(conffile="",
     asdf.get_config().add_extension(DISPXY_Extension())
 
     ref = WFC3IRGrismModel()
-    #ref = NIRCAMGrismModel()
     ref.meta.update(ref_kw)
     # This reference file is good for NRC_WFSS and TSGRISM modes
     ref.meta.exposure.p_exptype = "NRC_WFSS|NRC_TSGRISM"

--- a/HST/hst_grism_reffiles.py
+++ b/HST/hst_grism_reffiles.py
@@ -208,18 +208,18 @@ def create_grism_specwcs(conffile="",
         # This holds the x coefficients, for the R grism this model is the
         # the INVDISPX returning t, for the C grism this model is the DISPX
         e = beamdict[order]['DISPX']
-        xmodel = create_dispxy_model(e)
+        xmodel = create_dispxy_model(e)()
         dispx.append(xmodel)
         print(dispx)
-        inv_xmodel = create_dispxy_model(e, inverse=True)
+        inv_xmodel = create_dispxy_model(e, inverse=True)()
         invdispx.append(inv_xmodel)
 
         # This holds the y coefficients, for the C grism, this model is
         # the INVDISPY, returning t, for the R grism, this model is the DISPY
         e = beamdict[order]['DISPY']
-        ymodel = create_dispxy_model(e)
+        ymodel = create_dispxy_model(e)()
         dispy.append(ymodel)
-        inv_ymodel = create_dispxy_model(e, inverse=True)
+        inv_ymodel = create_dispxy_model(e, inverse=True)()
         invdispy.append(ymodel)
 
     # change the orders into translatable integers
@@ -234,7 +234,9 @@ def create_grism_specwcs(conffile="",
     ref.meta.output_units = u.micron
     ref.displ = displ
     ref.dispx = dispx
+    print(ref.dispx)
     ref.dispy = dispy
+    print(ref.dispy)
     ref.invdispx = invdispx
     ref.invdispy = invdispy
     ref.invdispl = invdispl

--- a/HST/wcs_ref_model.py
+++ b/HST/wcs_ref_model.py
@@ -1,0 +1,81 @@
+import warnings
+from astropy import units as u
+from stdatamodels.validate import ValidationWarning
+
+from jwst.datamodels import ReferenceFileModel
+
+class HST_IR_GrismModel(ReferenceFileModel):
+    """
+    A model for a reference file of type "specwcs" for HST IR grisms (G141 and
+    G102). This reference file contains the models for wave, x, and y \
+    polynomial solutions that describe dispersion through the grism.
+    Parameters
+    ----------
+    displ: `~astropy.modeling.Model`
+          HST Grism wavelength dispersion model
+    dispx : `~astropy.modeling.Model`
+          HST Grism row dispersion model
+    dispy : `~astropy.modeling.Model`
+          HST Grism column dispersion model
+    invdispl : `~astropy.modeling.Model`
+          HST Grism inverse wavelength dispersion model
+    invdispx : `~astropy.modeling.Model`
+          HST Grism inverse row dispersion model
+    invdispy : `~astropy.modeling.Model`
+          HST Grism inverse column dispersion model
+    orders : `~astropy.modeling.Model`
+          HST Grism orders, matched to the array locations of the
+          dispersion models
+    """
+    schema_url = "http://stsci.edu/schemas/jwst_datamodel/specwcs_nircam_grism.schema"
+    reftype = "specwcs"
+
+    def __init__(self, init=None,
+                       displ=None,
+                       dispx=None,
+                       dispy=None,
+                       invdispl=None,
+                       invdispx=None,
+                       invdispy=None,
+                       orders=None,
+                       **kwargs):
+        super(NIRCAMGrismModel, self).__init__(init=init, **kwargs)
+
+        if init is None:
+            self.populate_meta()
+        if displ is not None:
+            self.displ = displ
+        if dispx is not None:
+            self.dispx = dispx
+        if dispy is not None:
+            self.dispy = dispy
+        if invdispl is not None:
+            self.invdispl = invdispl
+        if invdispx is not None:
+            self.invdispx = invdispx
+        if invdispy is not None:
+            self.invdispy = invdispy
+        if orders is not None:
+            self.orders = orders
+
+    def populate_meta(self):
+        self.meta.instrument.name = "NIRCAM"
+        self.meta.exposure.type = "NRC_WFSS"
+        self.meta.reftype = self.reftype
+
+    def validate(self):
+        super(NIRCAMGrismModel, self).validate()
+        try:
+            assert isinstance(self.meta.input_units, (str, u.NamedUnit))
+            assert isinstance(self.meta.output_units, (str, u.NamedUnit))
+            assert self.meta.instrument.name == "NIRCAM"
+            assert self.meta.exposure.type == "NRC_WFSS"
+            assert self.meta.reftype == self.reftype
+        except AssertionError as errmsg:
+            if self._strict_validation:
+                raise AssertionError(errmsg)
+            else:
+                warnings.warn(str(errmsg), ValidationWarning)
+
+    def to_fits(self):
+        raise NotImplementedError("FITS format is not supported for this file.")

--- a/HST/wcs_ref_model.py
+++ b/HST/wcs_ref_model.py
@@ -4,7 +4,7 @@ from stdatamodels.validate import ValidationWarning
 
 from jwst.datamodels import ReferenceFileModel
 
-class HST_IR_GrismModel(ReferenceFileModel):
+class WFC3IRGrismModel(ReferenceFileModel):
     """
     A model for a reference file of type "specwcs" for HST IR grisms (G141 and
     G102). This reference file contains the models for wave, x, and y \
@@ -39,7 +39,7 @@ class HST_IR_GrismModel(ReferenceFileModel):
                        invdispy=None,
                        orders=None,
                        **kwargs):
-        super(NIRCAMGrismModel, self).__init__(init=init, **kwargs)
+        super(WFC3IRGrismModel, self).__init__(init=init, **kwargs)
 
         if init is None:
             self.populate_meta()
@@ -59,17 +59,17 @@ class HST_IR_GrismModel(ReferenceFileModel):
             self.orders = orders
 
     def populate_meta(self):
-        self.meta.instrument.name = "NIRCAM"
-        self.meta.exposure.type = "NRC_WFSS"
+        self.meta.instrument.name = "WFC3"
+        self.meta.exposure.type = "IR_GRISM"
         self.meta.reftype = self.reftype
 
     def validate(self):
-        super(NIRCAMGrismModel, self).validate()
+        super(WFC3IRGrismModel, self).validate()
         try:
             assert isinstance(self.meta.input_units, (str, u.NamedUnit))
             assert isinstance(self.meta.output_units, (str, u.NamedUnit))
-            assert self.meta.instrument.name == "NIRCAM"
-            assert self.meta.exposure.type == "NRC_WFSS"
+            assert self.meta.instrument.name == "WFC3"
+            assert self.meta.exposure.type == "IR_GRISM"
             assert self.meta.reftype == self.reftype
         except AssertionError as errmsg:
             if self._strict_validation:


### PR DESCRIPTION
Implements a script, using https://github.com/spacetelescope/jwreftools/blob/master/jwreftools/nircam/nircam_grism_reffiles.py as the basis, to encode the HST GRISMCONF files in the ASDF format that the JWST pipeline expects, so that we can leverage that grism processing code. 