### PR TITLE
Add function to extract 2D cutouts

### DIFF
--- a/HST/SpectrumExtraction.ipynb
+++ b/HST/SpectrumExtraction.ipynb
@@ -32,33 +32,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test[0].header"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test[1].header"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "#im = plt.imshow(test[1].data[250:350,100:600])\n",
     "im = plt.imshow(test[1].data)\n",
     "im.set_clim(0, 100)"
@@ -70,60 +43,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w = WCS(test[1].header)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ndc = ndcube.NDCube(test[1].data, w)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ndc"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reference_files = {}\n",
-    "specwcs_filename = \"wfc3_ir_specwcs.asdf\"\n",
-    "wavelengthrange_filename = \"../WFC3_wavelengthrange.asdf\"\n",
-    "dist_ref_path = \"../WFC3IR_distortion.asdf\"\n",
+    "# Finding where the object is in the direct image\n",
     "\n",
-    "reference_files['distortion'] = dist_ref_path\n",
-    "reference_files['wavelengthrange'] = wavelengthrange_filename\n",
-    "reference_files['specwcs'] = specwcs_filename"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from dispersion_models import DISPXY_Model, DISPXY_Extension\n",
-    "asdf.get_config().add_extension(DISPXY_Extension())\n",
+    "direct = fits.open(\"test_data/F140W/ib6o23rtq_flt.fits\")\n",
     "\n",
-    "specwcs = asdf.open(reference_files['specwcs']).tree\n",
-    "displ = specwcs['displ']\n",
-    "dispx = specwcs['dispx']\n",
-    "dispy = specwcs['dispy']\n",
-    "invdispl = specwcs['invdispl']\n",
-    "invdispx = specwcs['invdispx']\n",
-    "invdispy = specwcs['invdispy']\n",
-    "orders = specwcs['order']"
+    "im2 = plt.imshow(direct[1].data[270:320,140:200])\n",
+    "im2.set_clim(0, 100)"
    ]
   },
   {
@@ -132,71 +57,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "invdispx"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create grism pipeline\n",
+    "# Use the direct image bounding box to extract the 2D spectrum\n",
     "\n",
-    "from gwcs import coordinate_frames as cf\n",
-    "from astropy import units as u\n",
-    "from transform_models import WFC3IRForwardGrismDispersion, WFC3IRBackwardGrismDispersion\n",
-    "\n",
-    "gdetector = cf.Frame2D(name='grism_detector', \n",
-    "                       axes_order=(0, 1),\n",
-    "                       unit=(u.pix, u.pix))\n",
-    "det2det = WFC3IRForwardGrismDispersion(orders,\n",
-    "                                        lmodels=displ,\n",
-    "                                        xmodels=invdispx,\n",
-    "                                        ymodels=dispy)\n",
-    "det2det.inverse = WFC3IRBackwardGrismDispersion(orders,\n",
-    "                                              lmodels=invdispl,\n",
-    "                                              xmodels=dispx,\n",
-    "                                              ymodels=dispy)\n",
-    "\n",
-    "grism_pipeline = [(gdetector, det2det)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from gwcs import WCS\n",
-    "\n",
-    "wcsobj = WCS(grism_pipeline)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(wcsobj)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "det2det.inverse.evaluate(100,100,2, 1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from extraction import extract_2d_spectrum\n",
     "\n",
     "sliced_data = extract_2d_spectrum(test[1].data, 160, 285, 172, 300)"
@@ -219,35 +81,6 @@
    "source": [
     "plt.imshow(sliced_data)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Checking that the input coordinates I figured out to get that are actually\n",
-    "# where the source is...I worked a bit backwards. \n",
-    "\n",
-    "direct = fits.open(\"test_data/F140W/ib6o23rtq_flt.fits\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "im2 = plt.imshow(direct[1].data[270:320,140:200])\n",
-    "im2.set_clim(0, 100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/HST/SpectrumExtraction.ipynb
+++ b/HST/SpectrumExtraction.ipynb
@@ -2,13 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.382507Z",
-     "start_time": "2021-04-16T15:10:06.538393Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -24,13 +19,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.388069Z",
-     "start_time": "2021-04-16T15:10:07.383945Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "test = fits.open(\"test_data/ib6o23rsq_flt.fits\")"
@@ -38,519 +28,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.398951Z",
-     "start_time": "2021-04-16T15:10:07.389677Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7fadb8093310>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb250>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb670>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb6d0>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb910>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bbb50>, <astropy.io.fits.hdu.table.BinTableHDU object at 0x7fadc91bbc70>]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "test"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.407416Z",
-     "start_time": "2021-04-16T15:10:07.400033Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SIMPLE  =                    T / file does conform to FITS standard             \n",
-       "BITPIX  =                   16                                                  \n",
-       "NAXIS   =                    0                                                  \n",
-       "EXTEND  =                    T / FITS dataset may contain extensions            \n",
-       "COMMENT   FITS (Flexible Image Transport System) format is defined in 'Astronomy\n",
-       "COMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H \n",
-       "ORIGIN  = 'HSTIO/CFITSIO March 2010'                                            \n",
-       "DATE    = '2016-09-14' / date this file was written (yyyy-mm-dd)                \n",
-       "NEXTEND =                    6 / Number of standard extensions                  \n",
-       "FILENAME= 'ib6o23rsq_flt.fits' / name of file                                   \n",
-       "FILETYPE= 'SCI      '          / type of data found in data file                \n",
-       "                                                                                \n",
-       "TELESCOP= 'HST'                / telescope used to acquire data                 \n",
-       "INSTRUME= 'WFC3  '             / identifier for instrument used to acquire data \n",
-       "EQUINOX =               2000.0 / equinox of celestial coord. system             \n",
-       "                                                                                \n",
-       "              / DATA DESCRIPTION KEYWORDS                                       \n",
-       "                                                                                \n",
-       "ROOTNAME= 'ib6o23rsq                         ' / rootname of the observation set\n",
-       "IMAGETYP= 'EXT               ' / type of exposure identifier                    \n",
-       "PRIMESI = 'WFC3  '             / instrument designated as prime                 \n",
-       "                                                                                \n",
-       "              / TARGET INFORMATION                                              \n",
-       "                                                                                \n",
-       "TARGNAME= 'WFC3-ERSII-G01                ' / proposer's target name             \n",
-       "RA_TARG =   5.307083333333E+01 / right ascension of the target (deg) (J2000)    \n",
-       "DEC_TARG=  -2.771111111111E+01 / declination of the target (deg) (J2000)        \n",
-       "                                                                                \n",
-       "              / PROPOSAL INFORMATION                                            \n",
-       "                                                                                \n",
-       "PROPOSID=                11359 / PEP proposal identifier                        \n",
-       "LINENUM = '23.001         '    / proposal logsheet line number                  \n",
-       "PR_INV_L= 'O''Connell                    ' / last name of principal investigator\n",
-       "PR_INV_F= 'Robert              ' / first name of principal investigator         \n",
-       "PR_INV_M= 'W.                  ' / middle name / initial of principal investigat\n",
-       "                                                                                \n",
-       "              / EXPOSURE INFORMATION                                            \n",
-       "                                                                                \n",
-       "SUNANGLE=           127.366051 / angle between sun and V1 axis                  \n",
-       "MOONANGL=            60.330002 / angle between moon and V1 axis                 \n",
-       "SUN_ALT =           -20.195961 / altitude of the sun above Earth's limb         \n",
-       "FGSLOCK = 'FINE/GYRO         ' / commanded FGS lock (FINE,COARSE,GYROS,UNKNOWN) \n",
-       "GYROMODE= 'T'                  / number of gyros scheduled, T=3+OBAD            \n",
-       "REFFRAME= 'ICRS    '           / guide star catalog version                     \n",
-       "MTFLAG  = ' '                  / moving target flag; T if it is a moving target \n",
-       "                                                                                \n",
-       "DATE-OBS= '2009-10-03'         / UT date of start of observation (yyyy-mm-dd)   \n",
-       "TIME-OBS= '14:43:57'           / UT time of start of observation (hh:mm:ss)     \n",
-       "EXPSTART=   5.510761385738E+04 / exposure start time (Modified Julian Date)     \n",
-       "EXPEND  =   5.510762662294E+04 / exposure end time (Modified Julian Date)       \n",
-       "EXPTIME =          1102.935669 / exposure duration (seconds)--calculated        \n",
-       "EXPFLAG = 'NORMAL       '      / Exposure interruption indicator                \n",
-       "QUALCOM1= '                                                                    '\n",
-       "QUALCOM2= '                                                                    '\n",
-       "QUALCOM3= '                                                                    '\n",
-       "QUALITY = '                                                                    '\n",
-       "                                                                                \n",
-       "                                                                                \n",
-       "              / POINTING INFORMATION                                            \n",
-       "                                                                                \n",
-       "PA_V3   =           119.087196 / position angle of V3-axis of HST (deg)         \n",
-       "                                                                                \n",
-       "              / TARGET OFFSETS (POSTARGS)                                       \n",
-       "                                                                                \n",
-       "POSTARG1=           -10.012000 / POSTARG in axis 1 direction                    \n",
-       "POSTARG2=             5.058000 / POSTARG in axis 2 direction                    \n",
-       "                                                                                \n",
-       "              / DIAGNOSTIC KEYWORDS                                             \n",
-       "                                                                                \n",
-       "OPUS_VER= 'HSTDP 2016_1a     ' / data processing software system version        \n",
-       "CSYS_VER= 'hstdp-2016.1'       / Calibration software system version id         \n",
-       "CAL_VER = '3.3(28-Jan-2016)'   / CALWF3 code version                            \n",
-       "PROCTIME=   5.764553692130E+04 / Pipeline processing time (MJD)                 \n",
-       "                                                                                \n",
-       "              / INSTRUMENT CONFIGURATION INFORMATION                            \n",
-       "                                                                                \n",
-       "OBSTYPE = 'SPECTROSCOPIC '     / observation type - imaging or spectroscopic    \n",
-       "OBSMODE = 'MULTIACCUM'         / operating mode                                 \n",
-       "SCLAMP  = 'NONE          '     / lamp status, NONE or name of lamp which is on  \n",
-       "NRPTEXP =                    1 / number of repeat exposures in set: default 1   \n",
-       "SUBARRAY=                    F / data from a subarray (T) or full frame (F)     \n",
-       "SUBTYPE = 'FULLIMAG'           / Size/type of IR subarray                       \n",
-       "DETECTOR= 'IR  '               / detector in use: UVIS or IR                    \n",
-       "FILTER  = 'G141   '            / element selected from filter wheel             \n",
-       "SAMP_SEQ= 'SPARS100'           / MultiAccum exposure time sequence name         \n",
-       "NSAMP   =                   13 / number of MULTIACCUM samples                   \n",
-       "SAMPZERO=             2.911756 / sample time of the zeroth read (sec)           \n",
-       "APERTURE= 'IR              '   / aperture name                                  \n",
-       "PROPAPER= '                '   / proposed aperture name                         \n",
-       "DIRIMAGE= 'NONE     '          / direct image for grism or prism exposure       \n",
-       "                                                                                \n",
-       "              / POST-SAA DARK KEYWORDS                                          \n",
-       "                                                                                \n",
-       "SAA_EXIT= '                 '  / time of last exit from SAA contour level 23    \n",
-       "SAA_TIME=                    0 / seconds since last exit from SAA contour 23    \n",
-       "SAA_DARK= 'N/A      '          / association name for post-SAA dark exposures   \n",
-       "SAACRMAP= 'N/A               ' / SAA cosmic ray map file                        \n",
-       "                                                                                \n",
-       "              / SCAN KEYWORDS                                                   \n",
-       "                                                                                \n",
-       "SCAN_TYP= 'N                 ' / C:bostrophidon; D:C with dwell; N:N/A          \n",
-       "SCAN_WID=   0.000000000000E+00 / scan width (arcsec)                            \n",
-       "ANG_SIDE=   0.000000000000E+00 / angle between sides of parallelogram (deg)     \n",
-       "DWELL_LN=                    0 / dwell pts/line for scan pointing (1-99,0 if NA)\n",
-       "DWELL_TM=   0.000000000000E+00 / wait time (duration) at each dwell point (sec) \n",
-       "SCAN_ANG=   0.000000000000E+00 / position angle of scan line (deg)              \n",
-       "SCAN_RAT=   0.000000000000E+00 / commanded rate of the line scan (arcsec/sec)   \n",
-       "NO_LINES=                    0 / number of lines per scan (1-99,0 if NA)        \n",
-       "SCAN_LEN=   0.000000000000E+00 / scan length (arcsec)                           \n",
-       "SCAN_COR= 'C                 ' / scan coordinate frame of ref: celestial,vehicle\n",
-       "CSMID   = 'IR     '            / Channel Select Mechanism ID                    \n",
-       "                                                                                \n",
-       "              / CALIBRATION SWITCHES: PERFORM, OMIT, COMPLETE, SKIPPED          \n",
-       "                                                                                \n",
-       "DQICORR = 'COMPLETE'           / data quality initialization                    \n",
-       "ZSIGCORR= 'COMPLETE'           / Zero read signal correction                    \n",
-       "ZOFFCORR= 'COMPLETE'           / subtract MULTIACCUM zero read                  \n",
-       "DARKCORR= 'COMPLETE'           / Subtract dark image                            \n",
-       "BLEVCORR= 'COMPLETE'           / subtract bias level computed from ref pixels   \n",
-       "NLINCORR= 'COMPLETE'           / correct for detector nonlinearities            \n",
-       "FLATCORR= 'COMPLETE'           / flat field data                                \n",
-       "CRCORR  = 'COMPLETE'           / identify cosmic ray hits                       \n",
-       "UNITCORR= 'COMPLETE'           / convert to count rates                         \n",
-       "PHOTCORR= 'COMPLETE'           / populate photometric header keywords           \n",
-       "RPTCORR = 'OMIT    '           / combine individual repeat observations         \n",
-       "DRIZCORR= 'PERFORM '           / drizzle processing                             \n",
-       "                                                                                \n",
-       "              / CALIBRATION REFERENCE FILES                                     \n",
-       "                                                                                \n",
-       "BPIXTAB = 'iref$y711519pi_bpx.fits' / bad pixel table                           \n",
-       "CCDTAB  = 'iref$t2c16200i_ccd.fits' / detector calibration parameters           \n",
-       "OSCNTAB = 'iref$q911321mi_osc.fits' / detector overscan table                   \n",
-       "CRREJTAB= 'iref$u6a1748ri_crr.fits' / cosmic ray rejection parameters           \n",
-       "DARKFILE= 'iref$xag19293i_drk.fits' / dark image file name                      \n",
-       "NLINFILE= 'iref$u1k1727mi_lin.fits' / detector nonlinearities file              \n",
-       "PFLTFILE= 'iref$u4m1335mi_pfl.fits' / pixel to pixel flat field file name       \n",
-       "DFLTFILE= 'N/A                    ' / delta flat field file name                \n",
-       "LFLTFILE= 'N/A                    ' / low order flat                            \n",
-       "GRAPHTAB= 'N/A                    ' / the HST graph table                       \n",
-       "COMPTAB = 'N/A                    ' / the HST components table                  \n",
-       "IMPHTTAB= 'iref$wbj1825ri_imp.fits' / Image Photometry Table                    \n",
-       "IDCTAB  = 'iref$w3m18525i_idc.fits' / image distortion correction table         \n",
-       "DGEOFILE= 'N/A               ' / Distortion correction image                    \n",
-       "MDRIZTAB= 'iref$ubi1853pi_mdz.fits' / MultiDrizzle parameter table              \n",
-       "                                                                                \n",
-       "              / COSMIC RAY REJECTION ALGORITHM PARAMETERS                       \n",
-       "                                                                                \n",
-       "MEANEXP =                  0.0 / reference exposure time for parameters         \n",
-       "SCALENSE=                  0.0 / multiplicative scale factor applied to noise   \n",
-       "INITGUES= '   '                / initial guess method (MIN or MED)              \n",
-       "SKYSUB  = '    '               / sky value subtracted (MODE or NONE)            \n",
-       "SKYSUM  =                  0.0 / sky level from the sum of all constituent image\n",
-       "CRSIGMAS= '               '    / statistical rejection criteria                 \n",
-       "CRRADIUS=                  0.0 / rejection propagation radius (pixels)          \n",
-       "CRTHRESH=             0.000000 / rejection propagation threshold                \n",
-       "BADINPDQ=                    0 / data quality flag bits to reject               \n",
-       "REJ_RATE=                  0.0 / rate at which pixels are affected by cosmic ray\n",
-       "CRMASK  =                    F / flag CR-rejected pixels in input files (T/F)   \n",
-       "                                                                                \n",
-       "              / PHOTOMETRY KEYWORDS                                             \n",
-       "                                                                                \n",
-       "PHOTMODE= 'WFC3 IR G141'       / observation con                                \n",
-       "PHOTFLAM=        1.2561173E-20 / inverse sensitivity, ergs/cm2/Ang/electron     \n",
-       "PHOTFNU =        8.0799474E-08 / inverse sensitivity, Jy*sec/electron           \n",
-       "PHOTZPT =       -2.1100000E+01 / ST magnitude zero point                        \n",
-       "PHOTPLAM=        1.3886717E+04 / Pivot wavelength (Angstroms)                   \n",
-       "PHOTBW  =        1.6666720E+03 / RMS bandwidth of filter plus detector          \n",
-       "                                                                                \n",
-       "              / OTFR KEYWORDS                                                   \n",
-       "                                                                                \n",
-       "T_SGSTAR= '                  ' / OMS calculated guide star control              \n",
-       "                                                                                \n",
-       "              / PATTERN KEYWORDS                                                \n",
-       "                                                                                \n",
-       "PATTERN1= 'NONE                    ' / primary pattern type                     \n",
-       "P1_SHAPE= '                  ' / primary pattern shape                          \n",
-       "P1_PURPS= '          '         / primary pattern purpose                        \n",
-       "P1_NPTS =                    0 / number of points in primary pattern            \n",
-       "P1_PSPAC=             0.000000 / point spacing for primary pattern (arc-sec)    \n",
-       "P1_LSPAC=             0.000000 / line spacing for primary pattern (arc-sec)     \n",
-       "P1_ANGLE=             0.000000 / angle between sides of parallelogram patt (deg)\n",
-       "P1_FRAME= '         '          / coordinate frame of primary pattern            \n",
-       "P1_ORINT=             0.000000 / orientation of pattern to coordinate frame (deg\n",
-       "P1_CENTR= '   '                / center pattern relative to pointing (yes/no)   \n",
-       "PATTSTEP=                    0 / position number of this point in the pattern   \n",
-       "                                                                                \n",
-       "              / ENGINEERING PARAMETERS                                          \n",
-       "                                                                                \n",
-       "CCDAMP  = 'ABCD'               / CCD Amplifier Readout Configuration            \n",
-       "CCDGAIN =                  2.5 / commanded gain of CCD                          \n",
-       "CCDOFSAB=                  190 / commanded CCD bias offset for amps A&B         \n",
-       "CCDOFSCD=                  190 / commanded CCD bias offset for amps C&D         \n",
-       "                                                                                \n",
-       "              / CALIBRATED ENGINEERING PARAMETERS                               \n",
-       "                                                                                \n",
-       "ATODGNA =        2.3399999E+00 / calibrated gain for amplifier A                \n",
-       "ATODGNB =        2.3699999E+00 / calibrated gain for amplifier B                \n",
-       "ATODGNC =        2.3099999E+00 / calibrated gain for amplifier C                \n",
-       "ATODGND =        2.3800001E+00 / calibrated gain for amplifier D                \n",
-       "READNSEA=        2.0200001E+01 / calibrated read noise for amplifier A          \n",
-       "READNSEB=        1.9799999E+01 / calibrated read noise for amplifier B          \n",
-       "READNSEC=        1.9900000E+01 / calibrated read noise for amplifier C          \n",
-       "READNSED=        2.0100000E+01 / calibrated read noise for amplifier D          \n",
-       "BIASLEVA=             0.000000 / bias level for amplifier A                     \n",
-       "BIASLEVB=             0.000000 / bias level for amplifier B                     \n",
-       "BIASLEVC=             0.000000 / bias level for amplifier C                     \n",
-       "BIASLEVD=             0.000000 / bias level for amplifier D                     \n",
-       "                                                                                \n",
-       "              / ASSOCIATION KEYWORDS                                            \n",
-       "                                                                                \n",
-       "ASN_ID  = 'IB6O23010 '         / unique identifier assigned to association      \n",
-       "ASN_TAB = 'ib6o23010_asn.fits     ' / name of the association table             \n",
-       "ASN_MTYP= 'EXP-DTH     '       / Role of the Member in the Association          \n",
-       "CRDS_CTX= 'hst_0477.pmap'                                                       \n",
-       "CRDS_VER= '7.0.1, opus_2016.1-universal, af27872'                               \n",
-       "ATODTAB = 'N/A     '                                                            \n",
-       "BIACFILE= 'N/A     '                                                            \n",
-       "BIASFILE= 'N/A     '                                                            \n",
-       "D2IMFILE= 'N/A     '                                                            \n",
-       "DRKCFILE= 'N/A     '                                                            \n",
-       "FLSHFILE= 'N/A     '                                                            \n",
-       "NPOLFILE= 'N/A     '                                                            \n",
-       "PCTETAB = 'N/A     '                                                            \n",
-       "SNKCFILE= 'N/A     '                                                            \n",
-       "UPWCSVER= '1.2.3.dev'          / Version of STWCS used to updated the WCS       \n",
-       "PYWCSVER= '1.2.1   '           / Version of PYWCS used to updated the WCS       \n",
-       "DISTNAME= 'ib6o23rsq_w3m18525i-NOMODEL-NOMODEL'                                 \n",
-       "SIPNAME = 'ib6o23rsq_w3m18525i'                                                 \n",
-       "HISTORY CCD parameters table:                                                   \n",
-       "HISTORY   reference table iref$t2c16200i_ccd.fits                               \n",
-       "HISTORY     Ground                                                              \n",
-       "HISTORY     Reference data based on Thermal-Vac #3, gain=2.5 results for IR-4   \n",
-       "HISTORY     Readnoise,gain,saturation from TV3,MEB2 values. ISRs 2008-25,39,50  \n",
-       "HISTORY DQICORR complete ...                                                    \n",
-       "HISTORY   DQ array initialized ...                                              \n",
-       "HISTORY   reference table iref$y711519pi_bpx.fits                               \n",
-       "HISTORY     INFLIGHT 09/07/2009 18/02/2010                                      \n",
-       "HISTORY     BPIXTAB from SMOV flats & darks, with time-dependent blob masks---- \n",
-       "HISTORY ZSIGCORR complete.                                                      \n",
-       "HISTORY BLEVCORR complete.                                                      \n",
-       "HISTORY   Overscan region table:                                                \n",
-       "HISTORY   reference table iref$q911321mi_osc.fits                               \n",
-       "HISTORY     GROUND                                                              \n",
-       "HISTORY     Initial values for ground test data processing                      \n",
-       "HISTORY ZOFFCORR complete.                                                      \n",
-       "HISTORY Uncertainty array initialized.                                          \n",
-       "HISTORY NLINCORR complete ...                                                   \n",
-       "HISTORY   reference image iref$u1k1727mi_lin.fits                               \n",
-       "HISTORY     INFLIGHT 09/02/2009 12/07/2009                                      \n",
-       "HISTORY     Non-linearity correction from WFC3 MEB1 TV3 and on-orbit frames---- \n",
-       "HISTORY DARKCORR complete ...                                                   \n",
-       "HISTORY   reference image iref$xag19293i_drk.fits                               \n",
-       "HISTORY     INFLIGHT 04/09/2009 31/12/2012                                      \n",
-       "HISTORY     Dark Created from 186 (74 cy17, 78 cy18, 31 cy19, 3 cy20) ramps---- \n",
-       "HISTORY PHOTCORR complete ...                                                   \n",
-       "HISTORY   reference table iref$wbj1825ri_imp.fits                               \n",
-       "HISTORY     INFLIGHT 08/05/2009 06/04/2012                                      \n",
-       "HISTORY     photometry keywords reference file--------------------------------- \n",
-       "HISTORY UNITCORR complete.                                                      \n",
-       "HISTORY CRCORR complete.                                                        \n",
-       "HISTORY UNITCORR complete.                                                      \n",
-       "HISTORY FLATCORR complete ...                                                   \n",
-       "HISTORY   reference image iref$u4m1335mi_pfl.fits                               \n",
-       "HISTORY     INFLIGHT 01/08/2009 01/04/2010                                      \n",
-       "HISTORY     G141 gain conversion flat------------------------------------------ "
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "test[0].header"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.414691Z",
-     "start_time": "2021-04-16T15:10:07.408591Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "XTENSION= 'IMAGE   '           / IMAGE extension                                \n",
-       "BITPIX  =                  -32                                                  \n",
-       "NAXIS   =                    2                                                  \n",
-       "NAXIS1  =                 1014                                                  \n",
-       "NAXIS2  =                 1014                                                  \n",
-       "PCOUNT  =                    0 / required keyword; must = 0                     \n",
-       "GCOUNT  =                    1 / required keyword; must = 1                     \n",
-       "ORIGIN  = 'HSTIO/CFITSIO March 2010'                                            \n",
-       "DATE    = '2016-09-14' / date this file was written (yyyy-mm-dd)                \n",
-       "INHERIT =                    T / inherit the primary header                     \n",
-       "EXTNAME = 'SCI     '           / extension name                                 \n",
-       "EXTVER  =                    1 / extension version number                       \n",
-       "ROOTNAME= 'ib6o23rsq                         ' / rootname of the observation set\n",
-       "EXPNAME = 'ib6o23rsq                ' / exposure identifier                     \n",
-       "BUNIT   = 'ELECTRONS/S'        / brightness units                               \n",
-       "                                                                                \n",
-       "              / World Coordinate System and Related Parameters                  \n",
-       "                                                                                \n",
-       "WCSAXES =                    2 / number of World Coordinate System axes         \n",
-       "CRPIX1  =                507.0 / x-coordinate of reference pixel                \n",
-       "CRPIX2  =                507.0 / y-coordinate of reference pixel                \n",
-       "CRVAL1  =     53.0734956586377 / first axis value at reference pixel            \n",
-       "CRVAL2  =   -27.70721823660666 / second axis value at reference pixel           \n",
-       "CTYPE1  = 'RA---TAN-SIP'       / the coordinate type for the first axis         \n",
-       "CTYPE2  = 'DEC--TAN-SIP'       / the coordinate type for the second axis        \n",
-       "CD1_1   = 3.61482227373837E-05 / partial of first axis coordinate w.r.t. x      \n",
-       "CD1_2   = 9.42092247971798E-06 / partial of first axis coordinate w.r.t. y      \n",
-       "CD2_1   = 1.04266330591494E-05 / partial of second axis coordinate w.r.t. x     \n",
-       "CD2_2   = -3.2255821017724E-05 / partial of second axis coordinate w.r.t. y     \n",
-       "LTV1    =        0.0000000E+00 / offset in X to subsection start                \n",
-       "LTV2    =        0.0000000E+00 / offset in Y to subsection start                \n",
-       "LTM1_1  =                  1.0 / reciprocal of sampling rate in X               \n",
-       "LTM2_2  =                  1.0 / reciprocal of sampling rate in Y               \n",
-       "PA_APER =              163.778 / Position Angle of reference aperture center (de\n",
-       "VAFACTOR=   1.000051816987E+00 / velocity aberration plate scale factor         \n",
-       "ORIENTAT=              163.778 / position angle of image y axis (deg. e of n)   \n",
-       "RA_APER =   5.307341407653E+01 / RA of aperture reference position              \n",
-       "DEC_APER=  -2.770899251213E+01 / Declination of aperture reference position     \n",
-       "                                                                                \n",
-       "              / REPEATED EXPOSURES INFORMATION                                  \n",
-       "                                                                                \n",
-       "NCOMBINE=                    1 / number of image sets combined during CR rejecti\n",
-       "                                                                                \n",
-       "              / READOUT DEFINITION PARAMETERS                                   \n",
-       "                                                                                \n",
-       "CENTERA1=                  513 / subarray axis1 center pt in unbinned dect. pix \n",
-       "CENTERA2=                  513 / subarray axis2 center pt in unbinned dect. pix \n",
-       "SIZAXIS1=                 1024 / subarray axis1 size in unbinned detector pixels\n",
-       "SIZAXIS2=                 1024 / subarray axis2 size in unbinned detector pixels\n",
-       "BINAXIS1=                    1 / axis1 data bin size in unbinned detector pixels\n",
-       "BINAXIS2=                    1 / axis2 data bin size in unbinned detector pixels\n",
-       "                                                                                \n",
-       "              / READOUT PARAMETERS                                              \n",
-       "                                                                                \n",
-       "SAMPNUM =                   12 / MULTIACCUM sample number                       \n",
-       "SAMPTIME=          1102.935669 / total integration time (sec)                   \n",
-       "DELTATIM=           100.000313 / integration time of this sample (sec)          \n",
-       "ROUTTIME=   5.510762662294E+04 / UT time of array readout (MJD)                 \n",
-       "TDFTRANS=                    0 / number of TDF transitions during current sample\n",
-       "                                                                                \n",
-       "              / DATA PACKET INFORMATION                                         \n",
-       "                                                                                \n",
-       "FILLCNT =                    0 / number of segments containing fill             \n",
-       "ERRCNT  =                    0 / number of segments containing errors           \n",
-       "PODPSFF =                    F / podps fill present (T/F)                       \n",
-       "STDCFFF =                    F / science telemetry fill data present (T=1/F=0)  \n",
-       "STDCFFP = '0x5569'             / science telemetry fill pattern (hex)           \n",
-       "                                                                                \n",
-       "              / IMAGE STATISTICS AND DATA QUALITY FLAGS                         \n",
-       "                                                                                \n",
-       "NGOODPIX=              1002965 / number of good pixels                          \n",
-       "SDQFLAGS=                31743 / serious data quality flags                     \n",
-       "GOODMIN =       -1.5400983E+00 / minimum value of good pixels                   \n",
-       "GOODMAX =        1.5517249E+02 / maximum value of good pixels                   \n",
-       "GOODMEAN=        9.2970192E-01 / mean value of good pixels                      \n",
-       "SNRMIN  =        1.2313307E-02 / minimum signal to noise of good pixels         \n",
-       "SNRMAX  =        7.2329807E-01 / maximum signal to noise of good pixels         \n",
-       "SNRMEAN =        3.6682274E-02 / mean value of signal to noise of good pixels   \n",
-       "SOFTERRS=                    0 / number of soft error pixels (DQF=1)            \n",
-       "MEANDARK=        2.2464146E+01 / average of the dark values subtracted          \n",
-       "MEANBLEV=        1.4466604E+04 / average of all bias levels subtracted          \n",
-       "RADESYS = 'ICRS    '                                                            \n",
-       "OCX10   = 0.000778564193751663                                                  \n",
-       "OCX11   =    0.135431244969368                                                  \n",
-       "OCY10   =   0.1209636405110359                                                  \n",
-       "OCY11   = -0.00041851671994663                                                  \n",
-       "IDCSCALE=   0.1282500028610229                                                  \n",
-       "IDCTHETA=                 45.0                                                  \n",
-       "IDCXREF =                507.0                                                  \n",
-       "IDCYREF =                507.0                                                  \n",
-       "IDCV2REF=    1.019000053405762                                                  \n",
-       "IDCV3REF=  -0.5070000290870667                                                  \n",
-       "WCSNAMEO= 'OPUS    '                                                            \n",
-       "WCSAXESO=                    2                                                  \n",
-       "CRPIX1O =                492.0                                                  \n",
-       "CRPIX2O =                557.0                                                  \n",
-       "CDELT1O =                  1.0                                                  \n",
-       "CDELT2O =                  1.0                                                  \n",
-       "CUNIT1O = 'deg     '                                                            \n",
-       "CUNIT2O = 'deg     '                                                            \n",
-       "CTYPE1O = 'RA---TAN'                                                            \n",
-       "CTYPE2O = 'DEC--TAN'                                                            \n",
-       "CRVAL1O =       53.07341407653                                                  \n",
-       "CRVAL2O =      -27.70899251213                                                  \n",
-       "LONPOLEO=                180.0                                                  \n",
-       "LATPOLEO=      -27.70899251213                                                  \n",
-       "RADESYSO= 'ICRS    '                                                            \n",
-       "CD1_1O  =          3.61933E-05                                                  \n",
-       "CD1_2O  =          9.41344E-06                                                  \n",
-       "CD2_1O  =          1.04347E-05                                                  \n",
-       "CD2_2O  =         -3.23551E-05                                                  \n",
-       "IDCTAB  = 'iref$w3m18525i_idc.fits'                                             \n",
-       "B_0_3   = -2.3813607426051E-10                                                  \n",
-       "B_ORDER =                    4                                                  \n",
-       "A_3_0   = -2.3716200728180E-10                                                  \n",
-       "B_1_2   = 6.31243430776636E-11                                                  \n",
-       "A_ORDER =                    4                                                  \n",
-       "B_2_2   = -1.7580091715687E-13                                                  \n",
-       "A_2_1   = 1.29289254704036E-10                                                  \n",
-       "A_1_1   = 2.44084308174762E-05                                                  \n",
-       "A_2_2   = 2.35753629384072E-14                                                  \n",
-       "A_2_0   = -2.4133465663211E-07                                                  \n",
-       "A_1_3   = 5.17856894659408E-13                                                  \n",
-       "B_3_1   = 5.60993015610249E-14                                                  \n",
-       "A_0_2   = 5.33092691853019E-08                                                  \n",
-       "B_2_1   = -3.0827896112996E-10                                                  \n",
-       "A_1_2   = 2.81394789152228E-11                                                  \n",
-       "A_4_0   = -2.8102976693048E-13                                                  \n",
-       "A_0_4   = -2.0211147283637E-13                                                  \n",
-       "B_1_1   = -1.7107385824843E-07                                                  \n",
-       "B_0_4   = 7.23205168173609E-13                                                  \n",
-       "B_4_0   = -5.9243852454034E-13                                                  \n",
-       "A_3_1   = 5.43714947358335E-13                                                  \n",
-       "B_3_0   = 3.51974158902385E-11                                                  \n",
-       "B_1_3   = -5.1674434652779E-14                                                  \n",
-       "B_2_0   = 6.95458963321812E-06                                                  \n",
-       "A_0_3   = 3.73753772880087E-11                                                  \n",
-       "B_0_2   = 2.99270373714981E-05                                                  \n",
-       "WCSNAME = 'IDC_w3m18525i'                                                       \n",
-       "MDRIZSKY=   0.8787192461264526 / Sky value computed by AstroDrizzle             "
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "test[1].header"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.564081Z",
-     "start_time": "2021-04-16T15:10:07.442957Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAABmCAYAAADS4coNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAQQ0lEQVR4nO2dXczk1lnHf48978fuZpOyyWZZmlXSiC2QC1ogShPoRSlqFSpEb6oqERK5iJQbkIqEBImQkJC4gBsKSAh1JapyATQgWjWKKkKalts2hX6QNmy6iTZKoiSbZD+ym3ff952xHy5sz3jm9XzPeOzx/yeNPD7+OMeP7f95/JzjY3N3hBBC1I9g1QUQQggxGxJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKXMJuJndb2ZnzeycmT26qEIJIYQYj83aD9zMQuAF4BPAq8CzwIPu/uPFFU8IIcQw5vHA7wHOuftL7r4PfBn49GKKJYQQYhzzCPj7gVdy86+maUIIIUqgtewMzOwR4BGAkPBXDnPjsrMUQoi14iqX3nb344Pp8wj4a8Cp3PxtaVof7n4GOANwox3zj4SfnCNLIUQhHoPN8UA97/ZiqXwjevzlovR5ztizwGkz+4CZbQIPAE/MsT8hxKzMK74S71oyswfu7h0z+33gKSAEvujuP5p8BxPW+B4nU11gjcHCEACPohWXRIhqM1cM3N2/Dnx9po0nFeRphVuPgrVHwi3EZKyf0km8hRCrJIsalIDUTgghFkmJTqQEXAghaooEXAjRLDwuNcyxTCTgQohmYcFsYY64eo3r5Qv4mtR8QoglUGV9MFt1CQ5QvoCrl4gQYhhV1ocKlq16JRJiHamyZ1lFZK+JWJ2A6wSJJlFB703Un9VdVbqgK48F1Yv5iQVQB+epyfowxflpsJXEODye7WtNokIUiUGROC5I1LNxbMQcTFF5ScBFrdBTwZQsa8yhIWgcm3KRgIvaIPEWop+lf5FHiEWhkE5D0IiiE1M/K9WhAUZ0WYXXHGxulJ5nZViH+2OceK/DMS6I+nngqpkXzrQi67FPtc0iRbwo70HP3DudheVXO5pwfzThGCd8CqmfgIsuq4oJrzIWXZT3qDSFXUQtmbCSkoBXmNo12lnQ/3ibXYTjurKN+mzenI/LeRtKzNcExci7rK+A1/AkzyTYeZGswvEWlWFcuUYtn+WTekN3JTFfC9yBilzvK2Z9BbwmJ3eoaE9S/r5tl/MChZnhXmGxiz2xQybIg3areINX+HN3QicievHlVRdluSzSwQhq/rLQAm2xvgI+J61bbyF+b4f4vZ2l5XFAvPMntSium4qplTmsZRBgcTVF0N17dsrbK+9dDwnjWGCV8MKjsy+tugjlUBOHqhQWaAsJ+BDiy1fwqCThGhDuPoEO+k+2wfTjEmf7yIQ4mPICyvIbtl0cT7bPRVQE7kl53BlqBYvTVVOBjn10PF6ImiIBH0K8317q/rvedyYsmXAHQSJQqSBO5W0XhWNiT7z2MIAw6EsvXL+wsNZbt8hrnXT8izCcLRyTVRBx3KtMhtnFvbtuN/yThVhy4l0F71tMSVXaeSqEBLxE+kQ7E+wwxDZa2PY2bG3imxuwuYFvhHho9MlM6nmS6VB2Leedynxa7r8HydSGCegk6fkOJl3vNieqw/aRiaX78PwH8rPcNiPL6d63/15ajMcx1ulAu5OM0RFFiaDHjgUS83l7ORXZbamhKYn3AZop4CXV5H03SCbaYYi1WtjhQ7C9hR/eZu+nj3LxF7a4dsqJTu7xwVNv8sDPPMvpzTcAOBrss20RkRuhORejbSKMO1s7bFvArseEZtwUbHaza6WNmqEFtD3iWrzHrsfsOOx6yFvREQKL2bY2sQe8G28TWsz5/ePc3LrGe/EWITERAbvxBjvxFleiQ+xEm1zuHOZaZ5P9uMVb12/gUKtN7MaVvW0MiNyI4oB2JyR2Y7/dYn+3hceGRwHsBxA4dAzrJDay2Aj2DRyC9OEnaCfzFiVREXOw9B2dIKJ/WewEnV5a2HZa152tyx02Lu4SXnkPdq7je/vJiz5RlIh6Q8R8ZHvLKPINxIP7DOndS7mnm1krhnWyvYUheLz0Y5pIwM3sPHAViICOu99tZseAx4E7gPPAZ9390nKKuSBG9TeedPspts2fPAtiiAM87iTeoTvWbmN7+2xFMTf7jRy+sMHeTVu8esvt/Pktp4i3HQ8dWo5tRljohGFMHAcEQcyhQ/sc2mzTCmK2Wh0Otdocbu2zGUQcae1xQ7jHDa09NiwiwNkO2mxYxIZ1CMw5EuxxPHyX7aDNreE13vMNjobX+dXtNzlsIRsWsmX1ey297RGX4l2+cvWDfOn8fVz8wXFueuFGjr6yz9ZbOwRXr8P1XXx/v+ude6fTJ+ZVFpORApk6CsDBtpTUeaDVSkJqyUrJNAyTEFt+m3wbwsDTTTbf187gcV8bRTe9u7/cI1wu3btPXUPaJ/qeAovXGRqam+Q8ztEuMvQ6KamtZRoP/Nfd/e3c/KPAM+7+F2b2aDr/xwst3aKZ1+ueY/vkRCdDbXoUYZ0Ofv16ss+Ll9h4JWQjDNNYdZh0lcrCLPnYeLcs1r3hPAyAkNhaXAuOQGBcDALcLAmj5BoYPezF1z00PEj270b3xjuzkW5LGnoJkuXe90SRTIKOE28YccuSNE/WM/dkH0a6b7r7MIe4lXjOHqTpYS+/bH2cvu1x8JAkr1wZPEi8c2KI0/omiKC142xdibn97V1a71wnuLaDX9/F99tdLzyrTPMx8iqLN/TKN7Gnm147ll4zFgbQavXaNtLry1tDRDwv4FlaPtSVmyeKD3rtPrB9JsL5SgGGi/0ElYF1Vx04d4OCX7j84H09sq0m75gVNf/M8DQy6zU3Twjl08DH0v//CPwX0wi4GiQSPPXMibA4xtv0NWTmT2thg+aIR+OiS2fhHRCHncdMGA4UIDi4HgPHVnico172ycXgu+0ESQycKIJOB49i4na7J9ZZ2am+YA+juNxR5if0XztB2p6yw/Dzla2bs3/XOy5IWwmD/f4XwZK85TKuq0kF3IH/NDMHvuDuZ4AT7v56uvwN4MRUOTdcvPsGZeqKeHpxpoPiDwq2j+uql390HdZLY8w+ZutjXjCI/4hx/YsEwJnypaFRXRLzDaxZfiWItoVhZT9o0H+86fWVr/xzxS6yzKTWmmSwsbmppokXw5Rh3kkF/KPu/pqZ3Qo8bWb/15enu6fifgAzewR4BGCbw/0FbbiI95GduDgX7sgEPWOEOEwsvGMExqFf5PNd+PLTachXLNk8HEib6DYfjLEOIy/eJVFV8R7GKGEdHAxsmmEI6vpEUwmm1MSJBNzdX0unF8zsq8A9wJtmdtLdXzezk8CFIdueAc4A3GjH8q16UxV0rUgrr/5Gzpw3nidiIlt5Xv7m7B5mA+LXbVwanI4qzxjhLPK2s0ooe9t02OP7sPX6GBQRvcAzFQeG6JUoz84SndWxezWzI2Z2NPsPfBJ4DngCeChd7SHga0sp4TpScDI99u6vYOHkP0jEa46fR3HyFurAfPfnfnCa/dL5bjmKSF8uOnCY3kvPL8/vf+h6g8cxaLemsqDjr93ImFViic7qJB74CeCrqdfTAv7Z3f/DzJ4F/tXMHgZeBj67tFI2jELPfPKN58t8kost9uLp4PKiZePSF0GTBbuIBQiIPPBqMlbA3f0l4EMF6e8Av7GMQokek9442Rtw+emMGc623aIYHB4336gzZ9kaKUJNDlU2gGa+ibmGZOI0OJ2WZX9ebYIdjv8/8a4aKNjDqEKngSqUYc2QgIs+ZhG9opDPuP2ME/1pw0gS6wLiKOmxY0E1hLMKZVgz1kvA46j+g73XnEmFdBrBlTjPSBPuhYZ79et15LN+6GDVcV8hxGw0WLxh7QR8vQ5HCDECOV5rJuCzIuEXohALrLpCqfu2YQJe1QtRiIri+c/RicrRrDOjC3GtsMD0huA6IMdqZqRoorYMHXpA1IZgc6NxjlXmeBQ5H4Np4xyUZllOLI64XiPviRKZYvwVj5rpfQ/7nmg2zQv3KBFfr37gRTS8n+jSaEIf4ymo8ljgpTPNZwfzNpv3k4c1Ydjb0kWiPu4Jc/0FfM0vBlERFMedH92rUyOLCbEAFIsXq0ACLuZH3qcQK0ECvoZYuJz49NDGFD36jqeMSk4VaSVY1v1XhO68dWQRN3LBPhQmmIMyKjlVpJWgzMZsnfE1ZCFCW+LHgIUQsyEBF8Wom6AQlUcCLoSoLk2O609w7BLwZeKx3lgUYlaKBKxJgj5Bm8b6v8izSiwAjbVUTfSGbvUpOj86Z33IGkIIUVGC7a3Ry0sqhxDVQp7cejNJqKVq4ZiC8sS7eyM30VUshFg/Jqmgq1aJz1Ceih2BEGtI1Tw9sXymGFJ3HiTgi0I3qRAiw4KFePjjXsuXgC+Kqj2OzYk+VbZAsmujiZV8E495gYx7LX+9VEcsBAtM454IUQPMSxzzwsyuAmdLy7Da3AK8vepCVATZoods0UO26HG7ux8fTCz7RZ6z7n53yXlWEjP7rmyRIFv0kC16yBbjUQhFCCFqigRcCCFqStkCfqbk/KqMbNFDtughW/SQLcZQaiOmEEKIxaEQihBC1JTSBNzM7jezs2Z2zsweLSvfVWFmXzSzC2b2XC7tmJk9bWY/Sac/laabmf1tapsfmtkvr67ki8XMTpnZt8zsx2b2IzP7XJreRFtsm9l3zOwHqS3+LE3/gJl9Oz3mx81sM03fSufPpcvvWOkBLAEzC83se2b2ZDrfWFvMQikCbmYh8HfAbwJ3AQ+a2V1l5L1CvgTcP5D2KPCMu58GnknnIbHL6fT3CPD3JZWxDDrAH7r7XcC9wO+l576JttgDPu7uHwI+DNxvZvcCfwl83t1/FrgEPJyu/zBwKU3/fLreuvE54PncfJNtMT3uvvQfcB/wVG7+MeCxMvJe5Q+4A3guN38WOJn+P0nSLx7gC8CDReut2w/4GvCJptsCOAz8D/ARkpdVWml6914BngLuS/+30vVs1WVfoA1uI6m8Pw48SfL5k0baYtZfWSGU9wOv5OZfTdOaxgl3fz39/wZwIv3fCPukj72/BHybhtoiDRl8H7gAPA28CFx29066Sv54u7ZIl18Bbi61wMvlr4E/ArIBU26mubaYCTVirghPXInGdAEysxuAfwf+wN3fzS9rki3cPXL3D5N4n/cAP7/aEq0GM/st4IK7//eqy1JnyhLw14BTufnb0rSm8aaZnQRIpxfS9LW2j5ltkIj3P7n7V9LkRtoiw90vA98iCRO8z8yyYS3yx9u1Rbr8JuCdcku6NH4N+G0zOw98mSSM8jc00xYzU5aAPwucTluYN4EHgCdKyrtKPAE8lP5/iCQenKX/btoD417gSi68UGvMzIB/AJ5397/KLWqiLY6b2fvS/4dI2gKeJxHyz6SrDdois9FngG+mTyu1x90fc/fb3P0OEj34prv/Dg20xVyU2GDxKeAFkpjfn6w6+F/C8f4L8DrQJonlPUwSs3sG+AnwDeBYuq6R9NJ5Efhf4O5Vl3+BdvgoSXjkh8D309+nGmqLXwS+l9riOeBP0/Q7ge8A54B/A7bS9O10/ly6/M5VH8OS7PIx4EnZYvqf3sQUQoiaokZMIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKf8PYs52K6I82L8AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "im = plt.imshow(test[1].data[250:350,100:600])\n",
+    "#im = plt.imshow(test[1].data[250:350,100:600])\n",
+    "im = plt.imshow(test[1].data)\n",
     "im.set_clim(0, 100)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.645266Z",
-     "start_time": "2021-04-16T15:10:07.634156Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "w = WCS(test[1].header)"
@@ -558,13 +75,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:07.813314Z",
-     "start_time": "2021-04-16T15:10:07.810889Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "ndc = ndcube.NDCube(test[1].data, w)"
@@ -572,42 +84,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:08.799684Z",
-     "start_time": "2021-04-16T15:10:08.795703Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<ndcube.ndcube.NDCube object at 0x7fadc920a490>\n",
-       "NDCube\n",
-       "------\n",
-       "Dimensions: [1014. 1014.] pix\n",
-       "Physical Types of Axes: [('pos.eq.ra', 'pos.eq.dec'), ('pos.eq.ra', 'pos.eq.dec')]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "ndc"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:09.545870Z",
-     "start_time": "2021-04-16T15:10:09.542732Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "reference_files = {}\n",
@@ -622,13 +109,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:10.421689Z",
-     "start_time": "2021-04-16T15:10:09.933663Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from dispersion_models import DISPXY_Model, DISPXY_Extension\n",
@@ -646,43 +128,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:11.080624Z",
-     "start_time": "2021-04-16T15:10:11.077125Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<DISPXY_Model(name='DISPXY_Model')>,\n",
-       " <DISPXY_Model(name='DISPXY_Model')>,\n",
-       " <DISPXY_Model(name='DISPXY_Model')>,\n",
-       " <DISPXY_Model(name='DISPXY_Model')>,\n",
-       " <DISPXY_Model(name='DISPXY_Model')>,\n",
-       " <DISPXY_Model(name='DISPXY_Model')>]"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "invdispx"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:12.014304Z",
-     "start_time": "2021-04-16T15:10:12.009025Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create grism pipeline\n",
@@ -708,13 +164,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:12.984001Z",
-     "start_time": "2021-04-16T15:10:12.980791Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from gwcs import WCS\n",
@@ -724,138 +175,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:13.797306Z",
-     "start_time": "2021-04-16T15:10:13.793772Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     From      Transform\n",
-      "-------------- ---------\n",
-      "grism_detector      None\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(wcsobj)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:10:14.492174Z",
-     "start_time": "2021-04-16T15:10:14.487574Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(343.35376024540244, 104.13834046833674, 100, 100, 1)"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "det2det.inverse.evaluate(100,100,2, 1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:30:23.272302Z",
-     "start_time": "2021-04-16T15:30:23.087332Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(204.26972147408998, 286.8536012589572, 160, 285, 1) (339.55872878229144, 302.99753117068565, 165, 300, 1)\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from extraction import extract_2d_spectrum\n",
     "\n",
-    "sliced_data = extract_2d_spectrum(test[1].data, 160, 285, 165, 300)"
+    "sliced_data = extract_2d_spectrum(test[1].data, 160, 285, 172, 300)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:30:23.512410Z",
-     "start_time": "2021-04-16T15:30:23.509139Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(17, 136)"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "sliced_data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-16T15:30:23.933346Z",
-     "start_time": "2021-04-16T15:30:23.840091Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fae088cfb20>"
-      ]
-     },
-     "execution_count": 65,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAABMCAYAAAB01uxdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAdhUlEQVR4nO2da6wtyVXff6t6P849d8YeD0YTZ8aKJ4qVyLFCQAgcgSKEiWITi8mHCNlBiqNYmi+JQhASGcsfUL4RJcpLvDQCYxMhm8QhYYRIeDhEfMIxJJFjbAzDKx5rzBjmee+55+zdVSsfqqp3de/u3r3fe1/qLx2d3fVc9ej/qrWqultUlYyMjIyM84M5tgAZGRkZGZshE3hGRkbGmSITeEZGRsaZIhN4RkZGxpkiE3hGRkbGmSITeEZGRsaZYisCF5F3icgXRORZEXlqV0JlZGRkZKyGbHoOXEQK4LeBvwE8B3waeJ+qfm534mVkZGRkdGGbFfg3AM+q6u+p6gz4OPDEbsTKyMjIyFiF0RZ5HwW+mFw/B3xjX4aJTPWC21tUmZGRkfGnD6/x0h+r6lc3w7ch8EEQkSeBJwEuuOQb5Z37rnKVQBDdRiLHlSWjDjGg7v6rK+P+xgFeR/LL+ok/bAvfhsC/BLw5uX4shNWgqk8DTwO8Th7eX0vXIeNM3PuHtHjnImG2xfXlW0oiqNPhZW5RV62OTcodkrepTNbNn3FYnND7o7Yh8E8DbxWRx/HE/V7g7+5EqqE4NyLuI4yuG7gZt21ZQ9BGin0yDCXRTWRZKkJADFKAWruTMgdUutz+ofVum26b8esqoy1+SFjGSZE3bEHgqlqKyD8CfgEogA+r6m/uTLJVOAXybhLYkLR98V3lpHFDbuhtSa0tfx9ZH4JEm8jk0o10rPrGshnWTL/NuA6Zy+eILt45ErFv5QNX1Z8Hfn5HsrRj30S9C/LZFYFt6Vo4CI4sh3ed2KPKcDZYd6x2ObbnMJc3Qadi2pCntiT+0+7JU1hlZ2SAJ51zJp6M3WDXc0Bk8bcB9n4KZSNsStxndIOJ8W2sNuNa4tL4NGwXUKc7L/NYSPtwX22q6kjm2Cn1XzpPVs2pVWUMxdB52jbX1q3rpDBkj2qjckMfrbEqPy0CX5e490TYh7wxV9W1L1lWlrvKj7oJhm6urrkJK8ZtrpD6TsvEeHXrl33gkySpfJvOmW3mWl/etrht53WXAmhTKn3pdqJIuvaoDjDup0Pgq8h7TRI5pdVRK/o2QE/JkjiUX3TLOqvx3seeRtdNucf27ASbnpxJ867aXE/TDyGvHW1iDrm/d5WmCzXyH7JZvAdCPx6B9xF2z0Qb3OGnQoKpvE1tbwR/gCdjFSTMl/Z39xyyD89pvLaRtaj/jnO38/5r1hXytKYvlu+FM4SYYYS85H5bReRruFJOZwUe0UG8g4j7kKS9ieY+datgTxCRJeKVDfc52srqS5uiLd+QNIdGv7I6EnY937vi7gNib6JrX2IXOA6Bd928+3ya7k8DnNZN3xNRGG1EtFNySm+O1AfaVkdjVdiZJi3vwKSi3H8kNghneD58LWIe2r6T3sRck7x7V967Iu9mHasGZR1i7CCXneZNHiuPTydKm/W8ygxuxp/jamiIzOu0K027jU95HRxpQ+xU0Heq6KRPr2wzRhsuaI7oA+85jpVO3Ebckulttn3qsIcYV3XqkLwpka7rNkjrH5JXFaz1fRT7Jc23qj0tbsz7Dq5xk8V+aoa34lDWXls9w+o+KbfLuohHEXvmXV/cXjGInIuQdHEiaqXCqZR1y/19kj5wMcsnBsJ1Rc5N8jEmiUsa2lwBLSkCGabZtn08dh2S7MrfRtZdZfWkb23J0H7YJdpW+4dcPbWdFtnmZESb7OtabgdAlOikiHyQctwR9tXugW1Q1ZqSqSmcVmtuQfotlSbp2+s7LIFLWG0n/tlqtZisGn1YQvImeVKpmdf/WK5r25V5xKqBa6tnnQmb5ndu+borTxq3Ks/QVeaQ1+y2pekLS8P3dHPtjKz6CHio+2QXro513rFT1dvYJE4vVp4gaUHriamWuG0V9L5cQztUpqoKxYqlf7i3qt5om5PiFuVF8za1OkJf1E6trOifgxK4iEGmU6QofIcUBhmN/G9jYFSACFrElXkga2PQwpO4jkx1HdOpsL57wlBTcEtIBkCU5QER8fUOgDTHskFuQ8pZKiMW1TQ6WtKpdORP5dhyvosqmoyBJGWrSO26E1033QYk0dVfXqCuzuwIdyA2vH8lPPasHfNNVBflqFbpl8pfZ77Wxqlt07W//1uLbBuTvjxNefvSrhrr5hj2yTFU+a+pxMW19GmHpSqryk/jnNbDVCty10jy1obwcOjAqSd157wV7RKij+XN2qs+8ApckMmkTtzTCWoExiO0KKAIJA2eoI2gRtCxQUVwE4MrBAy4sb+RdNWL/jQhunQeaks8yze/OEWS9yep8eXUbuKWchflNSeoV8at5XS2IU6INHA5b60ubcjVJptrD0/Lq+qQ9rStZNGQsxbW1lxt/G/mHYpkTLvTaBUfx12UTuUgDsw83FSFLPq9pW89gS/6pJZOk/7cYNyr382FR1d7WhYdVZY0XSijdb605O1WgC1yN9Ho49bFjapvo0nq7SPQVceq+05BdSjEvjLiuEmzjCaRa/IHSBmI2zoIJK7WgTpflrU1MhfV5AZtx2EJ3Bjk8hZMxuh4BOMR9vYEHRnsxQg79StrN/Gk7EaL/3YCWkB5Ibgx/m/iSdCNtXePp+rWaJl2kHVzUlfXDkzZSGfAFUliaS/DV95cJncolCak5aKNGElW2c0luTZloZbJ51mOl5i3QfBq8P3YRrSa1Bf/TMijINbHiRN/k0hUYpHskvhAJl3WSe3GT9pQhbvkeknhtPSLtpQZ08bxT9vD4n+V1lFT9LW+IdbRsVJO6vcWZeh7pXWMxIHpeyljTZk0okL5adlt/VRrQgvRdvYtYYXbVNiJ7Iv+rROjRPJeVX8qA3Qr39Z8LQudWp5EgYD/ndbVIketPdEtEpSolH5lTfXfVmQupfUrb2tRU3gyL0sojCf3FUr+sAReGPT1D+AuJ9hbY+zUMHtohB0LsweF8tKTc3nLk7WbKq4AN3XopUVGyuXrrrmcznj9xTVvunyFqbE8Mn2VB4vrWlUm0VwFihHHhcwxohQ4ihBvw11YiMM0Zk4R0t51U160t5m7UZXvgeKaPzN6pcpXiGOMZSIWi2DV4DDV71gHwG2Z8aDx8toGgzs1VdhYLEWYGfG/CbPIJcyWhsW8Mf21jnjVXfj4hpazCHMdYUOdLshpMVgVrtyUKzfFIty4MQCvL+5xaW6wmEqGCzPH4LjWCTduHMotcGqYmjmXZoZT4cXyAeZa8Gp5wavlLYw4Xje6ZiyWy2LG1MyZuxGv2Fs4lWqsoky+XYvr0pnwv8CFdlv17bhxRRXuNP0zlGqYWx9XOoNq+N/oV+sM1gmlLbgpC1QFYxzGKCJKEfrdquCcwVqDLX15YtzCIm9oIVXxo6OCOn+NE9R5DSZFUGhWwAYtlk5NFcQKciML67GhVKvp72RB9DHMhDxBQVeKwsWVJTUFGpXYksJrhsW6FcychZIuEpm68ibKeqG4UmKs15MuErqUz0KZNCI6CLwvvbFaS7tUTyhTbKMvrGLmzvfJzHlrfm6RuUOcQ2YlWIeUFpmXflU+n4NTpLB+Vd6Dk3kSUxoTIF1VoVLNOG+RLG7G+G7oJkk6NTUSj4jkbXA4TJXek7AupTXi0xdotQwvUE+u4hhL6RUEjolYxlIyBuaMsDjGsLTKvjQ3XLQu1cCKVCQyFodBgyJZyGZCmcn9SCFgtR4GMFZX9YNLfE1GHE4NM4pKacQ+jIrnws25dDc4DNeBwB8qrrg0N1U6L2fJGMu1jrnWcSjPK4ELM+dC5jgMY/FpxmIZGcdYLA+P7jINaW6bG2Za8KC9jUVCP5dBWZhK7gKHxVRKIiofrzR9313ZSaVkvGIz1ZyZq2HmRlgVSufZpVSvECJcKKt0BusMd+cTFBgbh4hiRBnFfk3SXZf+liqMw4jiVDxBJ4hhTsE5L5cNCsAYx6jwecsQpirVvK/miTXYm6Ji2CVPQ0xrBWsT603jhAnkaGVh8TgWVlkswuiC3BMSFQWx9bAIAWQOxgpqtCLwyipyUrcuYl0Nq2DJQqRO5Km11epCaqZjEZa2s628FJ6YZVlZpZZF1SdJ/YH4zdwgCsWNekIvRxT3LOIUc1P4FfrcQmH8qjxq/rL0q/IerCRwEfkw8B7gBVV9ewh7GPhp4C3AHwDfqaovrSoLa5GXXqW4mmAmY8ajgsnLyy4UOzULF0oRXCjTEa4AezHlegxXI/jSBX6CjBcToHaviC7CorkOflLGCROgqSukWYYKUi7Mer+qUBi7cB1uoGT1VO9DarMoruJinIhf0dXSswgX/Co7XpuQJyKSBVCtXNO5FRVCTCO0r+TTNGlcWsa0sIwLi2Eh86jlnRBGFBMsH09GBffKMaV6kpuVI0aF5atuXXFRzJkYy7TwCnLuCpwKI2Nrq1yAqbFBqQaLpLJMXE1BuabWbGAkDoNQhPGahrLSfF5+pVTD3XKCU2FibCVXrDteR4VgRBkbW8VH+aJFEa2GVM475YSrcsLION44ucvI2NrYjBOFH62RGF9qwdwVrQuW0hXcuPptfquYc6uY1fLeuIJZS7pJWLSkCrTq47S/gywOwapwZz5l5kZMTMmksMk4+f6c2aKyhuKcjXNmFEyG0hXMwlyIc2LRn76PAW7siLktqjJg+Z5I/9ugNNN5rUGJpogKVoEyluEMzom3wAo/ejaERUULYIPF5uYGvS4QK5irAjOH0T1hfMdbKeM7ipkro2tldOUwc8fonkWsw1yXfoUO8MLS0ALDVuAfAX4Q+Mkk7Cngk6r6AyLyVLj+pytLcg69dw/m82oTs7gagTEU45F3sRiDjsNmpvEnTbxfvAj+blNtYNqxUJ3iCERdzanKJy3JZmEIM7LsD0982FodYQxx6n16or58FZ/fjZrlsjBPU594+juWG/MZcIHgq7Qt6as6ot89VVYmTatVWL1dumhPqlAa7SdNZ3T5yHmhmMIvN0yDuE1IHye3kcVD4c4Z5vMCdd7d4KxgRo7r2ZjpuPQr8qJulYyMq258h2BQxoX15CvOx4eVcM1ltkTuC5KvZBUXnpJfENM4WVEDTEzJ1JSUzjAxJU4Nt4pZRaax3Ms0LNQ5NmXluotxFzKnEMdMR8zDsjS6hF4sH+AVe4sLM+fRyUtcyKxy4UX3X4oiCbvrpsx1VIVXbcQx1xHX6q2naC3eNjc8aO4BeBcawrWOueumQSbfhgfNPW4Ha6ug3ocFdaswuu6iNfSyu+Sum3JhZtyWGUYcE7zynWvBtY6xarjSKVZNzRV5W2aMpawsurmOeNVe1FyAFzLnweIeBcrL1te1KEO5kDljCcon5IsW5lwLZlp4SzNYi069OzFaeECoOyjakPfajblxI8bGcml8u67stErn0wp37JR7dsJr5ZQ/ub7NTTnixbuXzG5G3LszYfbyCDOHyatCcSOMrpTxHcGUBZM7BjNXimmBuVf0bsivJHBV/VUReUsj+AngW8LvjwL/gyEErqCzud+FLUt/CqUcISL+aKExSBGOCYbjg4h4Yh+HI4YjsyD2UTxuyPLOfkqC8akooUb49RX4Il9TCaSbeenJkThmzXKXiDeVqyFbWldK9k0SX2ycSbJE77I8lvMvlbnU/v48VbqixaJJNiFjXGmo9R9489I4KJwg1pd159YtXit0sTma1tWwXAAovNVVk615nchUC0/jmzdFWlfoACkcYhS1Bi1D4wpFClflEVH/sZ5o3VSKURuW1MKiUhWcq3esLQucFaRQJpOystBi/qaVI6IUIU1pvbvKT/W6HHG1SYgzoowKxygoy7jqLK2pfscy0nRt1lsXnAozW2CdUBitFHPMa8Nq17uO/Mo1tSzHhVcH0S3lFEobHngJdRSijEe2JntqpRZGl+Ssr7YXv9O4iCinC32yOGiykLcI88C5RbqYtrYCvzFgheLKYErhIqzApYTJa+pX5deO8V2HWGV0ZZHSYWYl5rqkD5v6wB9R1efD7y8DjwzJpM7hrm/827mA1gd6/IX/nzyBKeEg/eIpTqkO1y89Xp9epw+5pA/+dD3U0FVW82EVkWSlLst50ydH23aS4xvnqnQ9dcd0zTRVGSzaE17W1HtETRp5Y1ldz6YkR+HqvxsJjdTLo55u4UP0vkAtBB3JQvn2HQet1d8ie5s8DTna27a6Tn8KyfuCtQA1I6+sagq8txqfLp1zcTql7/3QxAKURRqfd7mOKPvYwSTmbbhMR3GTkmg9+nLm8VYLcYUmb04IukqBeRJWW2S0+a9bYIGyOa0Tv7aEcjRYoipQpuliO5L0cXPUxj4Rvwfk2xhcI6vGo+HHrg4UySK66hOtp28u8Kp+S2VMfOBS+n4uZhp84s77w516d0mpmLn1ZO0cchP+lxbm+yHwCqqqIt0qWUSeBJ4EuOAS1KGVtrJI1Ipi/Mo8/bKIBKI3ZrEbmxByfGKzqnzIo/VD06Z1+HbWrhG/4mlVEM3fXSTeKC9FUzl0PnW6QkG0oaY00rQdeTQl9560dWun2ffJT6cLRVOYyoLpRNLFzfPXS2fUm/KswoqnE1UIG0+KqOIKE6yF4OKrlMiAupppks2vpnutig9hfe1Mjydq444W6/u7shgl6cOQb7nNbfOpbu1Jk9TSLKnfrWtc4/0UytG2BUwLquOJsrhHKutUfIErlbI2rqNILfU3j3mqqSviZl1RIVZHOIPyFwUzD/PILk6kmBuLKZ0/mRJPpMzmxOOGlPsh8D8SkTep6vMi8iY6Xeygqk8DTwO8Th4OtvbCHEzJ3Dc87ZwQ1yD2Cm0DPuQR+jWegtPGY+jaUn7vu62Hfrospu16TLl3Rd3S5rZ64/nURnyv/EsKo6d/hyqSlDSKDgW4Th0D4rXRH3Hl2wxvLU8VseEMb3TvwbC+WOfpy7bx7npNQWKJpOi1vFIlnJJsLK9HzlZLMZWtd8HQLVL9xMuw9jTP0rdalLUMA+ZV11BWz0Es2qpFo+5K2IV8Vd5gbUo8D279k5YyDw/1zEs/F631hO0cWlrPkeEhnz5sSuDPAO8HfiD8/9nBOZuTpfHSofpLXezCZdJy6k7biMtu8W6F5mtU+16rmmrhDatb+6MGm77fpbkT2YjbSP41ZOn7aML6fdCRvvPrL7QqOF3zW5/afMXrUBdcF4EPVLpLH7BI5qa0kO5SCV0uxKZ8TYtxWZDldM24BDp08dFXTuqGHJJvU4XWh3RFHcsrOuRMX6OQ5Be3eICnWgxUT2UmT2S6QHLpE5nbngMXkY/hNyzfKCLPAd+PJ+7/ICIfAP4Q+M5V5QxCy03V+1X2tvcmr4u2cpthJ/JhhN6XW/WhWhE08hvTTeyr0DexGib0Ug0tjyUPr3eDuGb/dL0IrA8xTyP9EAW05H6rydZGiMmG2FJhifU60A24TIypT6rnHupQKEPqaE217gKkZ0+oFW3yDi27D+mCI83bp6zT67iojGSdEnNcZTfeh0L6PpQeDDmF8r6OqHeuyttTqP/fal6vtzI6F+z1012bvq6zJd86cp3kp78ihr7OdpO36a1rfUV3TVudDbTNk00/P9eJTSy55ljvWqYu7OqtovtE3/1Xs54S5VstqtKd6tS1PGwunsyTmKswaCUesY4CGPKe5x2g67Nim3y3cRd17wJHI+5Nv6izbVldedb9glHq7mkomn18fq7phpFNFf6+0XztcXp4oQ8d1lHn65lXhfXVsSZa3V+1BD2kPeBVu8cl8KY/vApve5tNOI854CYZ+rXoTsQ5M/STVltYDEO+f7iUZtNPwPWtSk/FTTQEpyrriX7ournaU3R5w7wNh/60XnP/at39rLb0Q8LWsfrX+VDIUtaefuwqY1sXyt4x1CRr67jOpP2NHvSF+2adu0i3LMj65YlZ/4Zqpm/Lv853QPs2DA+IVZbJXtwPa9Z1cCtlqOto198OPfI3O9PPmMXr9TBgpb+LPFt8pKMNxyfwiHV8a1t+XHafH0YdrBy8IOtXsI8bZUj/DVEC26BrtdfTn0PIUdPV1p6VTqc8fX015GPVzXS7Jt9dYJt9qyEr4BXzvnnfrXUf7gCDOWXHH6o+HQKP2GSTZGhHHGBz9BS/mt32gdXaBD/m6imOSVe/bdqfbW1yJ7ghto7f/FSxratlyAmYUxy7ZI71KYxOTlj1ybS+478Bp0fgEfvY7T4hoj8k2iZQc1O4k9z3jUMqjyOb+SvRdkOvOxd3cbR2XexDuRxbYXVZBSc2h06XwCP6NNC+/Ju7HKQTVwZ95J4xDDtTeG3zbs25uFDMp0U0Z4kVfb/xfTJ4b+2cfOCboOsUyynhPj3XnrHAOjfyLq2bPiuquam3qzqOiU3bdDILkj2s3s+bwKFbS50Ssa8auFW+sJhmnbqy0jhJ7INMusrcZV2nQoKnIsda2OGKu4nzJ/AurOqMdV82tM8n0IYM8LraexfavmvHPCuHw2HX47jLevI88DiiX/z+JfCMjHND0922K2I4BMFkBX8UyCEfNBCRrwB3gT8+WKX7wRs5/zbA/dGO3IbTQG7DfvHnVPWrm4EHJXAAEfl1Vf36g1a6Y9wPbYD7ox25DaeB3IbjINs6GRkZGWeKTOAZGRkZZ4pjEPjTR6hz17gf2gD3RztyG04DuQ1HwMF94BkZGRkZu0F2oWRkZGScKQ5K4CLyLhH5gog8KyJPHbLuTSEibxaRXxGRz4nIb4rId4fwh0Xkl0Tkd8L/Nxxb1lUQkUJE/reI/Fy4flxEPhXG46dFZHJsGfsgIg+JyCdE5LdE5PMi8tfObRxE5HvCPPqsiHxMRC7OYRxE5MMi8oKIfDYJa+178fh3oT2fEZGvO57kC3S04V+E+fQZEfnPIvJQEvfB0IYviMjfPIrQK3AwAheRAvgh4N3A24D3icjbDlX/FiiB71XVtwHvAP5hkPsp4JOq+lbgk+H61PHdwOeT638O/GtV/QvAS8AHjiLVcPxb4L+p6l8CvgbflrMZBxF5FPjHwNer6tuBAngv5zEOHwHe1Qjr6vt3A28Nf08CP3IgGVfhIyy34ZeAt6vqXwF+G/ggQLjH3wv85ZDnhwOHnRQOuQL/BuBZVf09VZ0BHweeOGD9G0FVn1fV/xV+v4YnjUfxsn80JPso8LePIuBAiMhjwN8CfixcC/CtwCdCkpNug4i8HvjrwI8DqOpMVV/mzMYB//TzLREZAZfA85zBOKjqrwIvNoK7+v4J4CfV49eAh0TkTQcRtAdtbVDVX1TVMlz+GvBY+P0E8HFVvVHV3weexXPYSeGQBP4o8MXk+rkQdjYQkbcAXwt8CnhEVZ8PUV8GHjmWXAPxb4DvA+Izz18FvJxM3lMfj8eBrwA/EdxAPyYitzmjcVDVLwH/Evh/eOJ+BfgNzmscUnT1/bne6/8A+K/h91m0IW9iDoSIPAD8J+CfqOqraZz6ozwne5xHRN4DvKCqv3FsWbbACPg64EdU9Wvxr2SouUvOYBzegF/ZPQ78WeA2yyb9WeLU+34VRORDeHfpTx1blnVwSAL/EvDm5PqxEHbyEJExnrx/SlV/JgT/UTQLw/8XjiXfAHwT8B0i8gd419W34v3JDwVTHk5/PJ4DnlPVT4XrT+AJ/ZzG4duA31fVr6jqHPgZ/Nic0zik6Or7s7rXReTvA+8BvksX56rPog2HJPBPA28NO+4T/AbBMwesfyMEX/GPA59X1X+VRD0DvD/8fj/ws4eWbShU9YOq+piqvgXf7/9dVb8L+BXg74Rkp96GLwNfFJG/GILeCXyOMxoHvOvkHSJyGeZVbMPZjEMDXX3/DPD3wmmUdwCvJK6Wk4KIvAvvWvwOVb1Kop4B3isiUxF5HL8h+z+PIWMvVPVgf8C343d6fxf40CHr3kLmb8abhp8B/k/4+3a8D/mTwO8Avww8fGxZB7bnW4CfC7//PH5SPgv8R2B6bPlWyP5XgV8PY/FfgDec2zgA/wz4LeCzwL8HpucwDsDH8H77Od4a+kBX3wOCP3H2u8D/xZ+6OdU2PIv3dcd7+0eT9B8KbfgC8O5jy9/2l5/EzMjIyDhT5E3MjIyMjDNFJvCMjIyMM0Um8IyMjIwzRSbwjIyMjDNFJvCMjIyMM0Um8IyMjIwzRSbwjIyMjDNFJvCMjIyMM8X/BwL0sly10PtIAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "plt.imshow(sliced_data)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Checking that the input coordinates I figured out to get that are actually\n",
+    "# where the source is...I worked a bit backwards. \n",
+    "\n",
+    "direct = fits.open(\"test_data/F140W/ib6o23rtq_flt.fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im2 = plt.imshow(direct[1].data[270:320,140:200])\n",
+    "im2.set_clim(0, 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/HST/SpectrumExtraction.ipynb
+++ b/HST/SpectrumExtraction.ipynb
@@ -1,0 +1,889 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.382507Z",
+     "start_time": "2021-04-16T15:10:06.538393Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.colors as colors\n",
+    "import matplotlib.cbook as cbook\n",
+    "\n",
+    "import asdf\n",
+    "from astropy.io import fits\n",
+    "from astropy.wcs import WCS\n",
+    "import ndcube"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.388069Z",
+     "start_time": "2021-04-16T15:10:07.383945Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test = fits.open(\"test_data/ib6o23rsq_flt.fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.398951Z",
+     "start_time": "2021-04-16T15:10:07.389677Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7fadb8093310>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb250>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb670>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb6d0>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bb910>, <astropy.io.fits.hdu.image.ImageHDU object at 0x7fadc91bbb50>, <astropy.io.fits.hdu.table.BinTableHDU object at 0x7fadc91bbc70>]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.407416Z",
+     "start_time": "2021-04-16T15:10:07.400033Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SIMPLE  =                    T / file does conform to FITS standard             \n",
+       "BITPIX  =                   16                                                  \n",
+       "NAXIS   =                    0                                                  \n",
+       "EXTEND  =                    T / FITS dataset may contain extensions            \n",
+       "COMMENT   FITS (Flexible Image Transport System) format is defined in 'Astronomy\n",
+       "COMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H \n",
+       "ORIGIN  = 'HSTIO/CFITSIO March 2010'                                            \n",
+       "DATE    = '2016-09-14' / date this file was written (yyyy-mm-dd)                \n",
+       "NEXTEND =                    6 / Number of standard extensions                  \n",
+       "FILENAME= 'ib6o23rsq_flt.fits' / name of file                                   \n",
+       "FILETYPE= 'SCI      '          / type of data found in data file                \n",
+       "                                                                                \n",
+       "TELESCOP= 'HST'                / telescope used to acquire data                 \n",
+       "INSTRUME= 'WFC3  '             / identifier for instrument used to acquire data \n",
+       "EQUINOX =               2000.0 / equinox of celestial coord. system             \n",
+       "                                                                                \n",
+       "              / DATA DESCRIPTION KEYWORDS                                       \n",
+       "                                                                                \n",
+       "ROOTNAME= 'ib6o23rsq                         ' / rootname of the observation set\n",
+       "IMAGETYP= 'EXT               ' / type of exposure identifier                    \n",
+       "PRIMESI = 'WFC3  '             / instrument designated as prime                 \n",
+       "                                                                                \n",
+       "              / TARGET INFORMATION                                              \n",
+       "                                                                                \n",
+       "TARGNAME= 'WFC3-ERSII-G01                ' / proposer's target name             \n",
+       "RA_TARG =   5.307083333333E+01 / right ascension of the target (deg) (J2000)    \n",
+       "DEC_TARG=  -2.771111111111E+01 / declination of the target (deg) (J2000)        \n",
+       "                                                                                \n",
+       "              / PROPOSAL INFORMATION                                            \n",
+       "                                                                                \n",
+       "PROPOSID=                11359 / PEP proposal identifier                        \n",
+       "LINENUM = '23.001         '    / proposal logsheet line number                  \n",
+       "PR_INV_L= 'O''Connell                    ' / last name of principal investigator\n",
+       "PR_INV_F= 'Robert              ' / first name of principal investigator         \n",
+       "PR_INV_M= 'W.                  ' / middle name / initial of principal investigat\n",
+       "                                                                                \n",
+       "              / EXPOSURE INFORMATION                                            \n",
+       "                                                                                \n",
+       "SUNANGLE=           127.366051 / angle between sun and V1 axis                  \n",
+       "MOONANGL=            60.330002 / angle between moon and V1 axis                 \n",
+       "SUN_ALT =           -20.195961 / altitude of the sun above Earth's limb         \n",
+       "FGSLOCK = 'FINE/GYRO         ' / commanded FGS lock (FINE,COARSE,GYROS,UNKNOWN) \n",
+       "GYROMODE= 'T'                  / number of gyros scheduled, T=3+OBAD            \n",
+       "REFFRAME= 'ICRS    '           / guide star catalog version                     \n",
+       "MTFLAG  = ' '                  / moving target flag; T if it is a moving target \n",
+       "                                                                                \n",
+       "DATE-OBS= '2009-10-03'         / UT date of start of observation (yyyy-mm-dd)   \n",
+       "TIME-OBS= '14:43:57'           / UT time of start of observation (hh:mm:ss)     \n",
+       "EXPSTART=   5.510761385738E+04 / exposure start time (Modified Julian Date)     \n",
+       "EXPEND  =   5.510762662294E+04 / exposure end time (Modified Julian Date)       \n",
+       "EXPTIME =          1102.935669 / exposure duration (seconds)--calculated        \n",
+       "EXPFLAG = 'NORMAL       '      / Exposure interruption indicator                \n",
+       "QUALCOM1= '                                                                    '\n",
+       "QUALCOM2= '                                                                    '\n",
+       "QUALCOM3= '                                                                    '\n",
+       "QUALITY = '                                                                    '\n",
+       "                                                                                \n",
+       "                                                                                \n",
+       "              / POINTING INFORMATION                                            \n",
+       "                                                                                \n",
+       "PA_V3   =           119.087196 / position angle of V3-axis of HST (deg)         \n",
+       "                                                                                \n",
+       "              / TARGET OFFSETS (POSTARGS)                                       \n",
+       "                                                                                \n",
+       "POSTARG1=           -10.012000 / POSTARG in axis 1 direction                    \n",
+       "POSTARG2=             5.058000 / POSTARG in axis 2 direction                    \n",
+       "                                                                                \n",
+       "              / DIAGNOSTIC KEYWORDS                                             \n",
+       "                                                                                \n",
+       "OPUS_VER= 'HSTDP 2016_1a     ' / data processing software system version        \n",
+       "CSYS_VER= 'hstdp-2016.1'       / Calibration software system version id         \n",
+       "CAL_VER = '3.3(28-Jan-2016)'   / CALWF3 code version                            \n",
+       "PROCTIME=   5.764553692130E+04 / Pipeline processing time (MJD)                 \n",
+       "                                                                                \n",
+       "              / INSTRUMENT CONFIGURATION INFORMATION                            \n",
+       "                                                                                \n",
+       "OBSTYPE = 'SPECTROSCOPIC '     / observation type - imaging or spectroscopic    \n",
+       "OBSMODE = 'MULTIACCUM'         / operating mode                                 \n",
+       "SCLAMP  = 'NONE          '     / lamp status, NONE or name of lamp which is on  \n",
+       "NRPTEXP =                    1 / number of repeat exposures in set: default 1   \n",
+       "SUBARRAY=                    F / data from a subarray (T) or full frame (F)     \n",
+       "SUBTYPE = 'FULLIMAG'           / Size/type of IR subarray                       \n",
+       "DETECTOR= 'IR  '               / detector in use: UVIS or IR                    \n",
+       "FILTER  = 'G141   '            / element selected from filter wheel             \n",
+       "SAMP_SEQ= 'SPARS100'           / MultiAccum exposure time sequence name         \n",
+       "NSAMP   =                   13 / number of MULTIACCUM samples                   \n",
+       "SAMPZERO=             2.911756 / sample time of the zeroth read (sec)           \n",
+       "APERTURE= 'IR              '   / aperture name                                  \n",
+       "PROPAPER= '                '   / proposed aperture name                         \n",
+       "DIRIMAGE= 'NONE     '          / direct image for grism or prism exposure       \n",
+       "                                                                                \n",
+       "              / POST-SAA DARK KEYWORDS                                          \n",
+       "                                                                                \n",
+       "SAA_EXIT= '                 '  / time of last exit from SAA contour level 23    \n",
+       "SAA_TIME=                    0 / seconds since last exit from SAA contour 23    \n",
+       "SAA_DARK= 'N/A      '          / association name for post-SAA dark exposures   \n",
+       "SAACRMAP= 'N/A               ' / SAA cosmic ray map file                        \n",
+       "                                                                                \n",
+       "              / SCAN KEYWORDS                                                   \n",
+       "                                                                                \n",
+       "SCAN_TYP= 'N                 ' / C:bostrophidon; D:C with dwell; N:N/A          \n",
+       "SCAN_WID=   0.000000000000E+00 / scan width (arcsec)                            \n",
+       "ANG_SIDE=   0.000000000000E+00 / angle between sides of parallelogram (deg)     \n",
+       "DWELL_LN=                    0 / dwell pts/line for scan pointing (1-99,0 if NA)\n",
+       "DWELL_TM=   0.000000000000E+00 / wait time (duration) at each dwell point (sec) \n",
+       "SCAN_ANG=   0.000000000000E+00 / position angle of scan line (deg)              \n",
+       "SCAN_RAT=   0.000000000000E+00 / commanded rate of the line scan (arcsec/sec)   \n",
+       "NO_LINES=                    0 / number of lines per scan (1-99,0 if NA)        \n",
+       "SCAN_LEN=   0.000000000000E+00 / scan length (arcsec)                           \n",
+       "SCAN_COR= 'C                 ' / scan coordinate frame of ref: celestial,vehicle\n",
+       "CSMID   = 'IR     '            / Channel Select Mechanism ID                    \n",
+       "                                                                                \n",
+       "              / CALIBRATION SWITCHES: PERFORM, OMIT, COMPLETE, SKIPPED          \n",
+       "                                                                                \n",
+       "DQICORR = 'COMPLETE'           / data quality initialization                    \n",
+       "ZSIGCORR= 'COMPLETE'           / Zero read signal correction                    \n",
+       "ZOFFCORR= 'COMPLETE'           / subtract MULTIACCUM zero read                  \n",
+       "DARKCORR= 'COMPLETE'           / Subtract dark image                            \n",
+       "BLEVCORR= 'COMPLETE'           / subtract bias level computed from ref pixels   \n",
+       "NLINCORR= 'COMPLETE'           / correct for detector nonlinearities            \n",
+       "FLATCORR= 'COMPLETE'           / flat field data                                \n",
+       "CRCORR  = 'COMPLETE'           / identify cosmic ray hits                       \n",
+       "UNITCORR= 'COMPLETE'           / convert to count rates                         \n",
+       "PHOTCORR= 'COMPLETE'           / populate photometric header keywords           \n",
+       "RPTCORR = 'OMIT    '           / combine individual repeat observations         \n",
+       "DRIZCORR= 'PERFORM '           / drizzle processing                             \n",
+       "                                                                                \n",
+       "              / CALIBRATION REFERENCE FILES                                     \n",
+       "                                                                                \n",
+       "BPIXTAB = 'iref$y711519pi_bpx.fits' / bad pixel table                           \n",
+       "CCDTAB  = 'iref$t2c16200i_ccd.fits' / detector calibration parameters           \n",
+       "OSCNTAB = 'iref$q911321mi_osc.fits' / detector overscan table                   \n",
+       "CRREJTAB= 'iref$u6a1748ri_crr.fits' / cosmic ray rejection parameters           \n",
+       "DARKFILE= 'iref$xag19293i_drk.fits' / dark image file name                      \n",
+       "NLINFILE= 'iref$u1k1727mi_lin.fits' / detector nonlinearities file              \n",
+       "PFLTFILE= 'iref$u4m1335mi_pfl.fits' / pixel to pixel flat field file name       \n",
+       "DFLTFILE= 'N/A                    ' / delta flat field file name                \n",
+       "LFLTFILE= 'N/A                    ' / low order flat                            \n",
+       "GRAPHTAB= 'N/A                    ' / the HST graph table                       \n",
+       "COMPTAB = 'N/A                    ' / the HST components table                  \n",
+       "IMPHTTAB= 'iref$wbj1825ri_imp.fits' / Image Photometry Table                    \n",
+       "IDCTAB  = 'iref$w3m18525i_idc.fits' / image distortion correction table         \n",
+       "DGEOFILE= 'N/A               ' / Distortion correction image                    \n",
+       "MDRIZTAB= 'iref$ubi1853pi_mdz.fits' / MultiDrizzle parameter table              \n",
+       "                                                                                \n",
+       "              / COSMIC RAY REJECTION ALGORITHM PARAMETERS                       \n",
+       "                                                                                \n",
+       "MEANEXP =                  0.0 / reference exposure time for parameters         \n",
+       "SCALENSE=                  0.0 / multiplicative scale factor applied to noise   \n",
+       "INITGUES= '   '                / initial guess method (MIN or MED)              \n",
+       "SKYSUB  = '    '               / sky value subtracted (MODE or NONE)            \n",
+       "SKYSUM  =                  0.0 / sky level from the sum of all constituent image\n",
+       "CRSIGMAS= '               '    / statistical rejection criteria                 \n",
+       "CRRADIUS=                  0.0 / rejection propagation radius (pixels)          \n",
+       "CRTHRESH=             0.000000 / rejection propagation threshold                \n",
+       "BADINPDQ=                    0 / data quality flag bits to reject               \n",
+       "REJ_RATE=                  0.0 / rate at which pixels are affected by cosmic ray\n",
+       "CRMASK  =                    F / flag CR-rejected pixels in input files (T/F)   \n",
+       "                                                                                \n",
+       "              / PHOTOMETRY KEYWORDS                                             \n",
+       "                                                                                \n",
+       "PHOTMODE= 'WFC3 IR G141'       / observation con                                \n",
+       "PHOTFLAM=        1.2561173E-20 / inverse sensitivity, ergs/cm2/Ang/electron     \n",
+       "PHOTFNU =        8.0799474E-08 / inverse sensitivity, Jy*sec/electron           \n",
+       "PHOTZPT =       -2.1100000E+01 / ST magnitude zero point                        \n",
+       "PHOTPLAM=        1.3886717E+04 / Pivot wavelength (Angstroms)                   \n",
+       "PHOTBW  =        1.6666720E+03 / RMS bandwidth of filter plus detector          \n",
+       "                                                                                \n",
+       "              / OTFR KEYWORDS                                                   \n",
+       "                                                                                \n",
+       "T_SGSTAR= '                  ' / OMS calculated guide star control              \n",
+       "                                                                                \n",
+       "              / PATTERN KEYWORDS                                                \n",
+       "                                                                                \n",
+       "PATTERN1= 'NONE                    ' / primary pattern type                     \n",
+       "P1_SHAPE= '                  ' / primary pattern shape                          \n",
+       "P1_PURPS= '          '         / primary pattern purpose                        \n",
+       "P1_NPTS =                    0 / number of points in primary pattern            \n",
+       "P1_PSPAC=             0.000000 / point spacing for primary pattern (arc-sec)    \n",
+       "P1_LSPAC=             0.000000 / line spacing for primary pattern (arc-sec)     \n",
+       "P1_ANGLE=             0.000000 / angle between sides of parallelogram patt (deg)\n",
+       "P1_FRAME= '         '          / coordinate frame of primary pattern            \n",
+       "P1_ORINT=             0.000000 / orientation of pattern to coordinate frame (deg\n",
+       "P1_CENTR= '   '                / center pattern relative to pointing (yes/no)   \n",
+       "PATTSTEP=                    0 / position number of this point in the pattern   \n",
+       "                                                                                \n",
+       "              / ENGINEERING PARAMETERS                                          \n",
+       "                                                                                \n",
+       "CCDAMP  = 'ABCD'               / CCD Amplifier Readout Configuration            \n",
+       "CCDGAIN =                  2.5 / commanded gain of CCD                          \n",
+       "CCDOFSAB=                  190 / commanded CCD bias offset for amps A&B         \n",
+       "CCDOFSCD=                  190 / commanded CCD bias offset for amps C&D         \n",
+       "                                                                                \n",
+       "              / CALIBRATED ENGINEERING PARAMETERS                               \n",
+       "                                                                                \n",
+       "ATODGNA =        2.3399999E+00 / calibrated gain for amplifier A                \n",
+       "ATODGNB =        2.3699999E+00 / calibrated gain for amplifier B                \n",
+       "ATODGNC =        2.3099999E+00 / calibrated gain for amplifier C                \n",
+       "ATODGND =        2.3800001E+00 / calibrated gain for amplifier D                \n",
+       "READNSEA=        2.0200001E+01 / calibrated read noise for amplifier A          \n",
+       "READNSEB=        1.9799999E+01 / calibrated read noise for amplifier B          \n",
+       "READNSEC=        1.9900000E+01 / calibrated read noise for amplifier C          \n",
+       "READNSED=        2.0100000E+01 / calibrated read noise for amplifier D          \n",
+       "BIASLEVA=             0.000000 / bias level for amplifier A                     \n",
+       "BIASLEVB=             0.000000 / bias level for amplifier B                     \n",
+       "BIASLEVC=             0.000000 / bias level for amplifier C                     \n",
+       "BIASLEVD=             0.000000 / bias level for amplifier D                     \n",
+       "                                                                                \n",
+       "              / ASSOCIATION KEYWORDS                                            \n",
+       "                                                                                \n",
+       "ASN_ID  = 'IB6O23010 '         / unique identifier assigned to association      \n",
+       "ASN_TAB = 'ib6o23010_asn.fits     ' / name of the association table             \n",
+       "ASN_MTYP= 'EXP-DTH     '       / Role of the Member in the Association          \n",
+       "CRDS_CTX= 'hst_0477.pmap'                                                       \n",
+       "CRDS_VER= '7.0.1, opus_2016.1-universal, af27872'                               \n",
+       "ATODTAB = 'N/A     '                                                            \n",
+       "BIACFILE= 'N/A     '                                                            \n",
+       "BIASFILE= 'N/A     '                                                            \n",
+       "D2IMFILE= 'N/A     '                                                            \n",
+       "DRKCFILE= 'N/A     '                                                            \n",
+       "FLSHFILE= 'N/A     '                                                            \n",
+       "NPOLFILE= 'N/A     '                                                            \n",
+       "PCTETAB = 'N/A     '                                                            \n",
+       "SNKCFILE= 'N/A     '                                                            \n",
+       "UPWCSVER= '1.2.3.dev'          / Version of STWCS used to updated the WCS       \n",
+       "PYWCSVER= '1.2.1   '           / Version of PYWCS used to updated the WCS       \n",
+       "DISTNAME= 'ib6o23rsq_w3m18525i-NOMODEL-NOMODEL'                                 \n",
+       "SIPNAME = 'ib6o23rsq_w3m18525i'                                                 \n",
+       "HISTORY CCD parameters table:                                                   \n",
+       "HISTORY   reference table iref$t2c16200i_ccd.fits                               \n",
+       "HISTORY     Ground                                                              \n",
+       "HISTORY     Reference data based on Thermal-Vac #3, gain=2.5 results for IR-4   \n",
+       "HISTORY     Readnoise,gain,saturation from TV3,MEB2 values. ISRs 2008-25,39,50  \n",
+       "HISTORY DQICORR complete ...                                                    \n",
+       "HISTORY   DQ array initialized ...                                              \n",
+       "HISTORY   reference table iref$y711519pi_bpx.fits                               \n",
+       "HISTORY     INFLIGHT 09/07/2009 18/02/2010                                      \n",
+       "HISTORY     BPIXTAB from SMOV flats & darks, with time-dependent blob masks---- \n",
+       "HISTORY ZSIGCORR complete.                                                      \n",
+       "HISTORY BLEVCORR complete.                                                      \n",
+       "HISTORY   Overscan region table:                                                \n",
+       "HISTORY   reference table iref$q911321mi_osc.fits                               \n",
+       "HISTORY     GROUND                                                              \n",
+       "HISTORY     Initial values for ground test data processing                      \n",
+       "HISTORY ZOFFCORR complete.                                                      \n",
+       "HISTORY Uncertainty array initialized.                                          \n",
+       "HISTORY NLINCORR complete ...                                                   \n",
+       "HISTORY   reference image iref$u1k1727mi_lin.fits                               \n",
+       "HISTORY     INFLIGHT 09/02/2009 12/07/2009                                      \n",
+       "HISTORY     Non-linearity correction from WFC3 MEB1 TV3 and on-orbit frames---- \n",
+       "HISTORY DARKCORR complete ...                                                   \n",
+       "HISTORY   reference image iref$xag19293i_drk.fits                               \n",
+       "HISTORY     INFLIGHT 04/09/2009 31/12/2012                                      \n",
+       "HISTORY     Dark Created from 186 (74 cy17, 78 cy18, 31 cy19, 3 cy20) ramps---- \n",
+       "HISTORY PHOTCORR complete ...                                                   \n",
+       "HISTORY   reference table iref$wbj1825ri_imp.fits                               \n",
+       "HISTORY     INFLIGHT 08/05/2009 06/04/2012                                      \n",
+       "HISTORY     photometry keywords reference file--------------------------------- \n",
+       "HISTORY UNITCORR complete.                                                      \n",
+       "HISTORY CRCORR complete.                                                        \n",
+       "HISTORY UNITCORR complete.                                                      \n",
+       "HISTORY FLATCORR complete ...                                                   \n",
+       "HISTORY   reference image iref$u4m1335mi_pfl.fits                               \n",
+       "HISTORY     INFLIGHT 01/08/2009 01/04/2010                                      \n",
+       "HISTORY     G141 gain conversion flat------------------------------------------ "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test[0].header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.414691Z",
+     "start_time": "2021-04-16T15:10:07.408591Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "XTENSION= 'IMAGE   '           / IMAGE extension                                \n",
+       "BITPIX  =                  -32                                                  \n",
+       "NAXIS   =                    2                                                  \n",
+       "NAXIS1  =                 1014                                                  \n",
+       "NAXIS2  =                 1014                                                  \n",
+       "PCOUNT  =                    0 / required keyword; must = 0                     \n",
+       "GCOUNT  =                    1 / required keyword; must = 1                     \n",
+       "ORIGIN  = 'HSTIO/CFITSIO March 2010'                                            \n",
+       "DATE    = '2016-09-14' / date this file was written (yyyy-mm-dd)                \n",
+       "INHERIT =                    T / inherit the primary header                     \n",
+       "EXTNAME = 'SCI     '           / extension name                                 \n",
+       "EXTVER  =                    1 / extension version number                       \n",
+       "ROOTNAME= 'ib6o23rsq                         ' / rootname of the observation set\n",
+       "EXPNAME = 'ib6o23rsq                ' / exposure identifier                     \n",
+       "BUNIT   = 'ELECTRONS/S'        / brightness units                               \n",
+       "                                                                                \n",
+       "              / World Coordinate System and Related Parameters                  \n",
+       "                                                                                \n",
+       "WCSAXES =                    2 / number of World Coordinate System axes         \n",
+       "CRPIX1  =                507.0 / x-coordinate of reference pixel                \n",
+       "CRPIX2  =                507.0 / y-coordinate of reference pixel                \n",
+       "CRVAL1  =     53.0734956586377 / first axis value at reference pixel            \n",
+       "CRVAL2  =   -27.70721823660666 / second axis value at reference pixel           \n",
+       "CTYPE1  = 'RA---TAN-SIP'       / the coordinate type for the first axis         \n",
+       "CTYPE2  = 'DEC--TAN-SIP'       / the coordinate type for the second axis        \n",
+       "CD1_1   = 3.61482227373837E-05 / partial of first axis coordinate w.r.t. x      \n",
+       "CD1_2   = 9.42092247971798E-06 / partial of first axis coordinate w.r.t. y      \n",
+       "CD2_1   = 1.04266330591494E-05 / partial of second axis coordinate w.r.t. x     \n",
+       "CD2_2   = -3.2255821017724E-05 / partial of second axis coordinate w.r.t. y     \n",
+       "LTV1    =        0.0000000E+00 / offset in X to subsection start                \n",
+       "LTV2    =        0.0000000E+00 / offset in Y to subsection start                \n",
+       "LTM1_1  =                  1.0 / reciprocal of sampling rate in X               \n",
+       "LTM2_2  =                  1.0 / reciprocal of sampling rate in Y               \n",
+       "PA_APER =              163.778 / Position Angle of reference aperture center (de\n",
+       "VAFACTOR=   1.000051816987E+00 / velocity aberration plate scale factor         \n",
+       "ORIENTAT=              163.778 / position angle of image y axis (deg. e of n)   \n",
+       "RA_APER =   5.307341407653E+01 / RA of aperture reference position              \n",
+       "DEC_APER=  -2.770899251213E+01 / Declination of aperture reference position     \n",
+       "                                                                                \n",
+       "              / REPEATED EXPOSURES INFORMATION                                  \n",
+       "                                                                                \n",
+       "NCOMBINE=                    1 / number of image sets combined during CR rejecti\n",
+       "                                                                                \n",
+       "              / READOUT DEFINITION PARAMETERS                                   \n",
+       "                                                                                \n",
+       "CENTERA1=                  513 / subarray axis1 center pt in unbinned dect. pix \n",
+       "CENTERA2=                  513 / subarray axis2 center pt in unbinned dect. pix \n",
+       "SIZAXIS1=                 1024 / subarray axis1 size in unbinned detector pixels\n",
+       "SIZAXIS2=                 1024 / subarray axis2 size in unbinned detector pixels\n",
+       "BINAXIS1=                    1 / axis1 data bin size in unbinned detector pixels\n",
+       "BINAXIS2=                    1 / axis2 data bin size in unbinned detector pixels\n",
+       "                                                                                \n",
+       "              / READOUT PARAMETERS                                              \n",
+       "                                                                                \n",
+       "SAMPNUM =                   12 / MULTIACCUM sample number                       \n",
+       "SAMPTIME=          1102.935669 / total integration time (sec)                   \n",
+       "DELTATIM=           100.000313 / integration time of this sample (sec)          \n",
+       "ROUTTIME=   5.510762662294E+04 / UT time of array readout (MJD)                 \n",
+       "TDFTRANS=                    0 / number of TDF transitions during current sample\n",
+       "                                                                                \n",
+       "              / DATA PACKET INFORMATION                                         \n",
+       "                                                                                \n",
+       "FILLCNT =                    0 / number of segments containing fill             \n",
+       "ERRCNT  =                    0 / number of segments containing errors           \n",
+       "PODPSFF =                    F / podps fill present (T/F)                       \n",
+       "STDCFFF =                    F / science telemetry fill data present (T=1/F=0)  \n",
+       "STDCFFP = '0x5569'             / science telemetry fill pattern (hex)           \n",
+       "                                                                                \n",
+       "              / IMAGE STATISTICS AND DATA QUALITY FLAGS                         \n",
+       "                                                                                \n",
+       "NGOODPIX=              1002965 / number of good pixels                          \n",
+       "SDQFLAGS=                31743 / serious data quality flags                     \n",
+       "GOODMIN =       -1.5400983E+00 / minimum value of good pixels                   \n",
+       "GOODMAX =        1.5517249E+02 / maximum value of good pixels                   \n",
+       "GOODMEAN=        9.2970192E-01 / mean value of good pixels                      \n",
+       "SNRMIN  =        1.2313307E-02 / minimum signal to noise of good pixels         \n",
+       "SNRMAX  =        7.2329807E-01 / maximum signal to noise of good pixels         \n",
+       "SNRMEAN =        3.6682274E-02 / mean value of signal to noise of good pixels   \n",
+       "SOFTERRS=                    0 / number of soft error pixels (DQF=1)            \n",
+       "MEANDARK=        2.2464146E+01 / average of the dark values subtracted          \n",
+       "MEANBLEV=        1.4466604E+04 / average of all bias levels subtracted          \n",
+       "RADESYS = 'ICRS    '                                                            \n",
+       "OCX10   = 0.000778564193751663                                                  \n",
+       "OCX11   =    0.135431244969368                                                  \n",
+       "OCY10   =   0.1209636405110359                                                  \n",
+       "OCY11   = -0.00041851671994663                                                  \n",
+       "IDCSCALE=   0.1282500028610229                                                  \n",
+       "IDCTHETA=                 45.0                                                  \n",
+       "IDCXREF =                507.0                                                  \n",
+       "IDCYREF =                507.0                                                  \n",
+       "IDCV2REF=    1.019000053405762                                                  \n",
+       "IDCV3REF=  -0.5070000290870667                                                  \n",
+       "WCSNAMEO= 'OPUS    '                                                            \n",
+       "WCSAXESO=                    2                                                  \n",
+       "CRPIX1O =                492.0                                                  \n",
+       "CRPIX2O =                557.0                                                  \n",
+       "CDELT1O =                  1.0                                                  \n",
+       "CDELT2O =                  1.0                                                  \n",
+       "CUNIT1O = 'deg     '                                                            \n",
+       "CUNIT2O = 'deg     '                                                            \n",
+       "CTYPE1O = 'RA---TAN'                                                            \n",
+       "CTYPE2O = 'DEC--TAN'                                                            \n",
+       "CRVAL1O =       53.07341407653                                                  \n",
+       "CRVAL2O =      -27.70899251213                                                  \n",
+       "LONPOLEO=                180.0                                                  \n",
+       "LATPOLEO=      -27.70899251213                                                  \n",
+       "RADESYSO= 'ICRS    '                                                            \n",
+       "CD1_1O  =          3.61933E-05                                                  \n",
+       "CD1_2O  =          9.41344E-06                                                  \n",
+       "CD2_1O  =          1.04347E-05                                                  \n",
+       "CD2_2O  =         -3.23551E-05                                                  \n",
+       "IDCTAB  = 'iref$w3m18525i_idc.fits'                                             \n",
+       "B_0_3   = -2.3813607426051E-10                                                  \n",
+       "B_ORDER =                    4                                                  \n",
+       "A_3_0   = -2.3716200728180E-10                                                  \n",
+       "B_1_2   = 6.31243430776636E-11                                                  \n",
+       "A_ORDER =                    4                                                  \n",
+       "B_2_2   = -1.7580091715687E-13                                                  \n",
+       "A_2_1   = 1.29289254704036E-10                                                  \n",
+       "A_1_1   = 2.44084308174762E-05                                                  \n",
+       "A_2_2   = 2.35753629384072E-14                                                  \n",
+       "A_2_0   = -2.4133465663211E-07                                                  \n",
+       "A_1_3   = 5.17856894659408E-13                                                  \n",
+       "B_3_1   = 5.60993015610249E-14                                                  \n",
+       "A_0_2   = 5.33092691853019E-08                                                  \n",
+       "B_2_1   = -3.0827896112996E-10                                                  \n",
+       "A_1_2   = 2.81394789152228E-11                                                  \n",
+       "A_4_0   = -2.8102976693048E-13                                                  \n",
+       "A_0_4   = -2.0211147283637E-13                                                  \n",
+       "B_1_1   = -1.7107385824843E-07                                                  \n",
+       "B_0_4   = 7.23205168173609E-13                                                  \n",
+       "B_4_0   = -5.9243852454034E-13                                                  \n",
+       "A_3_1   = 5.43714947358335E-13                                                  \n",
+       "B_3_0   = 3.51974158902385E-11                                                  \n",
+       "B_1_3   = -5.1674434652779E-14                                                  \n",
+       "B_2_0   = 6.95458963321812E-06                                                  \n",
+       "A_0_3   = 3.73753772880087E-11                                                  \n",
+       "B_0_2   = 2.99270373714981E-05                                                  \n",
+       "WCSNAME = 'IDC_w3m18525i'                                                       \n",
+       "MDRIZSKY=   0.8787192461264526 / Sky value computed by AstroDrizzle             "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test[1].header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.564081Z",
+     "start_time": "2021-04-16T15:10:07.442957Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAABmCAYAAADS4coNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAQQ0lEQVR4nO2dXczk1lnHf48978fuZpOyyWZZmlXSiC2QC1ogShPoRSlqFSpEb6oqERK5iJQbkIqEBImQkJC4gBsKSAh1JapyATQgWjWKKkKalts2hX6QNmy6iTZKoiSbZD+ym3ff952xHy5sz3jm9XzPeOzx/yeNPD7+OMeP7f95/JzjY3N3hBBC1I9g1QUQQggxGxJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKXMJuJndb2ZnzeycmT26qEIJIYQYj83aD9zMQuAF4BPAq8CzwIPu/uPFFU8IIcQw5vHA7wHOuftL7r4PfBn49GKKJYQQYhzzCPj7gVdy86+maUIIIUqgtewMzOwR4BGAkPBXDnPjsrMUQoi14iqX3nb344Pp8wj4a8Cp3PxtaVof7n4GOANwox3zj4SfnCNLIUQhHoPN8UA97/ZiqXwjevzlovR5ztizwGkz+4CZbQIPAE/MsT8hxKzMK74S71oyswfu7h0z+33gKSAEvujuP5p8BxPW+B4nU11gjcHCEACPohWXRIhqM1cM3N2/Dnx9po0nFeRphVuPgrVHwi3EZKyf0km8hRCrJIsalIDUTgghFkmJTqQEXAghaooEXAjRLDwuNcyxTCTgQohmYcFsYY64eo3r5Qv4mtR8QoglUGV9MFt1CQ5QvoCrl4gQYhhV1ocKlq16JRJiHamyZ1lFZK+JWJ2A6wSJJlFB703Un9VdVbqgK48F1Yv5iQVQB+epyfowxflpsJXEODye7WtNokIUiUGROC5I1LNxbMQcTFF5ScBFrdBTwZQsa8yhIWgcm3KRgIvaIPEWop+lf5FHiEWhkE5D0IiiE1M/K9WhAUZ0WYXXHGxulJ5nZViH+2OceK/DMS6I+nngqpkXzrQi67FPtc0iRbwo70HP3DudheVXO5pwfzThGCd8CqmfgIsuq4oJrzIWXZT3qDSFXUQtmbCSkoBXmNo12lnQ/3ibXYTjurKN+mzenI/LeRtKzNcExci7rK+A1/AkzyTYeZGswvEWlWFcuUYtn+WTekN3JTFfC9yBilzvK2Z9BbwmJ3eoaE9S/r5tl/MChZnhXmGxiz2xQybIg3areINX+HN3QicievHlVRdluSzSwQhq/rLQAm2xvgI+J61bbyF+b4f4vZ2l5XFAvPMntSium4qplTmsZRBgcTVF0N17dsrbK+9dDwnjWGCV8MKjsy+tugjlUBOHqhQWaAsJ+BDiy1fwqCThGhDuPoEO+k+2wfTjEmf7yIQ4mPICyvIbtl0cT7bPRVQE7kl53BlqBYvTVVOBjn10PF6ImiIBH0K8317q/rvedyYsmXAHQSJQqSBO5W0XhWNiT7z2MIAw6EsvXL+wsNZbt8hrnXT8izCcLRyTVRBx3KtMhtnFvbtuN/yThVhy4l0F71tMSVXaeSqEBLxE+kQ7E+wwxDZa2PY2bG3imxuwuYFvhHho9MlM6nmS6VB2Leedynxa7r8HydSGCegk6fkOJl3vNieqw/aRiaX78PwH8rPcNiPL6d63/15ajMcx1ulAu5OM0RFFiaDHjgUS83l7ORXZbamhKYn3AZop4CXV5H03SCbaYYi1WtjhQ7C9hR/eZu+nj3LxF7a4dsqJTu7xwVNv8sDPPMvpzTcAOBrss20RkRuhORejbSKMO1s7bFvArseEZtwUbHaza6WNmqEFtD3iWrzHrsfsOOx6yFvREQKL2bY2sQe8G28TWsz5/ePc3LrGe/EWITERAbvxBjvxFleiQ+xEm1zuHOZaZ5P9uMVb12/gUKtN7MaVvW0MiNyI4oB2JyR2Y7/dYn+3hceGRwHsBxA4dAzrJDay2Aj2DRyC9OEnaCfzFiVREXOw9B2dIKJ/WewEnV5a2HZa152tyx02Lu4SXnkPdq7je/vJiz5RlIh6Q8R8ZHvLKPINxIP7DOndS7mnm1krhnWyvYUheLz0Y5pIwM3sPHAViICOu99tZseAx4E7gPPAZ9390nKKuSBG9TeedPspts2fPAtiiAM87iTeoTvWbmN7+2xFMTf7jRy+sMHeTVu8esvt/Pktp4i3HQ8dWo5tRljohGFMHAcEQcyhQ/sc2mzTCmK2Wh0Otdocbu2zGUQcae1xQ7jHDa09NiwiwNkO2mxYxIZ1CMw5EuxxPHyX7aDNreE13vMNjobX+dXtNzlsIRsWsmX1ey297RGX4l2+cvWDfOn8fVz8wXFueuFGjr6yz9ZbOwRXr8P1XXx/v+ude6fTJ+ZVFpORApk6CsDBtpTUeaDVSkJqyUrJNAyTEFt+m3wbwsDTTTbf187gcV8bRTe9u7/cI1wu3btPXUPaJ/qeAovXGRqam+Q8ztEuMvQ6KamtZRoP/Nfd/e3c/KPAM+7+F2b2aDr/xwst3aKZ1+ueY/vkRCdDbXoUYZ0Ofv16ss+Ll9h4JWQjDNNYdZh0lcrCLPnYeLcs1r3hPAyAkNhaXAuOQGBcDALcLAmj5BoYPezF1z00PEj270b3xjuzkW5LGnoJkuXe90SRTIKOE28YccuSNE/WM/dkH0a6b7r7MIe4lXjOHqTpYS+/bH2cvu1x8JAkr1wZPEi8c2KI0/omiKC142xdibn97V1a71wnuLaDX9/F99tdLzyrTPMx8iqLN/TKN7Gnm147ll4zFgbQavXaNtLry1tDRDwv4FlaPtSVmyeKD3rtPrB9JsL5SgGGi/0ElYF1Vx04d4OCX7j84H09sq0m75gVNf/M8DQy6zU3Twjl08DH0v//CPwX0wi4GiQSPPXMibA4xtv0NWTmT2thg+aIR+OiS2fhHRCHncdMGA4UIDi4HgPHVnico172ycXgu+0ESQycKIJOB49i4na7J9ZZ2am+YA+juNxR5if0XztB2p6yw/Dzla2bs3/XOy5IWwmD/f4XwZK85TKuq0kF3IH/NDMHvuDuZ4AT7v56uvwN4MRUOTdcvPsGZeqKeHpxpoPiDwq2j+uql390HdZLY8w+ZutjXjCI/4hx/YsEwJnypaFRXRLzDaxZfiWItoVhZT9o0H+86fWVr/xzxS6yzKTWmmSwsbmppokXw5Rh3kkF/KPu/pqZ3Qo8bWb/15enu6fifgAzewR4BGCbw/0FbbiI95GduDgX7sgEPWOEOEwsvGMExqFf5PNd+PLTachXLNk8HEib6DYfjLEOIy/eJVFV8R7GKGEdHAxsmmEI6vpEUwmm1MSJBNzdX0unF8zsq8A9wJtmdtLdXzezk8CFIdueAc4A3GjH8q16UxV0rUgrr/5Gzpw3nidiIlt5Xv7m7B5mA+LXbVwanI4qzxjhLPK2s0ooe9t02OP7sPX6GBQRvcAzFQeG6JUoz84SndWxezWzI2Z2NPsPfBJ4DngCeChd7SHga0sp4TpScDI99u6vYOHkP0jEa46fR3HyFurAfPfnfnCa/dL5bjmKSF8uOnCY3kvPL8/vf+h6g8cxaLemsqDjr93ImFViic7qJB74CeCrqdfTAv7Z3f/DzJ4F/tXMHgZeBj67tFI2jELPfPKN58t8kost9uLp4PKiZePSF0GTBbuIBQiIPPBqMlbA3f0l4EMF6e8Av7GMQokek9442Rtw+emMGc623aIYHB4336gzZ9kaKUJNDlU2gGa+ibmGZOI0OJ2WZX9ebYIdjv8/8a4aKNjDqEKngSqUYc2QgIs+ZhG9opDPuP2ME/1pw0gS6wLiKOmxY0E1hLMKZVgz1kvA46j+g73XnEmFdBrBlTjPSBPuhYZ79et15LN+6GDVcV8hxGw0WLxh7QR8vQ5HCDECOV5rJuCzIuEXohALrLpCqfu2YQJe1QtRiIri+c/RicrRrDOjC3GtsMD0huA6IMdqZqRoorYMHXpA1IZgc6NxjlXmeBQ5H4Np4xyUZllOLI64XiPviRKZYvwVj5rpfQ/7nmg2zQv3KBFfr37gRTS8n+jSaEIf4ymo8ljgpTPNZwfzNpv3k4c1Ydjb0kWiPu4Jc/0FfM0vBlERFMedH92rUyOLCbEAFIsXq0ACLuZH3qcQK0ECvoZYuJz49NDGFD36jqeMSk4VaSVY1v1XhO68dWQRN3LBPhQmmIMyKjlVpJWgzMZsnfE1ZCFCW+LHgIUQsyEBF8Wom6AQlUcCLoSoLk2O609w7BLwZeKx3lgUYlaKBKxJgj5Bm8b6v8izSiwAjbVUTfSGbvUpOj86Z33IGkIIUVGC7a3Ry0sqhxDVQp7cejNJqKVq4ZiC8sS7eyM30VUshFg/Jqmgq1aJz1Ceih2BEGtI1Tw9sXymGFJ3HiTgi0I3qRAiw4KFePjjXsuXgC+Kqj2OzYk+VbZAsmujiZV8E495gYx7LX+9VEcsBAtM454IUQPMSxzzwsyuAmdLy7Da3AK8vepCVATZoods0UO26HG7ux8fTCz7RZ6z7n53yXlWEjP7rmyRIFv0kC16yBbjUQhFCCFqigRcCCFqStkCfqbk/KqMbNFDtughW/SQLcZQaiOmEEKIxaEQihBC1JTSBNzM7jezs2Z2zsweLSvfVWFmXzSzC2b2XC7tmJk9bWY/Sac/laabmf1tapsfmtkvr67ki8XMTpnZt8zsx2b2IzP7XJreRFtsm9l3zOwHqS3+LE3/gJl9Oz3mx81sM03fSufPpcvvWOkBLAEzC83se2b2ZDrfWFvMQikCbmYh8HfAbwJ3AQ+a2V1l5L1CvgTcP5D2KPCMu58GnknnIbHL6fT3CPD3JZWxDDrAH7r7XcC9wO+l576JttgDPu7uHwI+DNxvZvcCfwl83t1/FrgEPJyu/zBwKU3/fLreuvE54PncfJNtMT3uvvQfcB/wVG7+MeCxMvJe5Q+4A3guN38WOJn+P0nSLx7gC8CDReut2w/4GvCJptsCOAz8D/ARkpdVWml6914BngLuS/+30vVs1WVfoA1uI6m8Pw48SfL5k0baYtZfWSGU9wOv5OZfTdOaxgl3fz39/wZwIv3fCPukj72/BHybhtoiDRl8H7gAPA28CFx29066Sv54u7ZIl18Bbi61wMvlr4E/ArIBU26mubaYCTVirghPXInGdAEysxuAfwf+wN3fzS9rki3cPXL3D5N4n/cAP7/aEq0GM/st4IK7//eqy1JnyhLw14BTufnb0rSm8aaZnQRIpxfS9LW2j5ltkIj3P7n7V9LkRtoiw90vA98iCRO8z8yyYS3yx9u1Rbr8JuCdcku6NH4N+G0zOw98mSSM8jc00xYzU5aAPwucTluYN4EHgCdKyrtKPAE8lP5/iCQenKX/btoD417gSi68UGvMzIB/AJ5397/KLWqiLY6b2fvS/4dI2gKeJxHyz6SrDdois9FngG+mTyu1x90fc/fb3P0OEj34prv/Dg20xVyU2GDxKeAFkpjfn6w6+F/C8f4L8DrQJonlPUwSs3sG+AnwDeBYuq6R9NJ5Efhf4O5Vl3+BdvgoSXjkh8D309+nGmqLXwS+l9riOeBP0/Q7ge8A54B/A7bS9O10/ly6/M5VH8OS7PIx4EnZYvqf3sQUQoiaokZMIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKRJwIYSoKf8PYs52K6I82L8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "im = plt.imshow(test[1].data[250:350,100:600])\n",
+    "im.set_clim(0, 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.645266Z",
+     "start_time": "2021-04-16T15:10:07.634156Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "w = WCS(test[1].header)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:07.813314Z",
+     "start_time": "2021-04-16T15:10:07.810889Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ndc = ndcube.NDCube(test[1].data, w)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:08.799684Z",
+     "start_time": "2021-04-16T15:10:08.795703Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ndcube.ndcube.NDCube object at 0x7fadc920a490>\n",
+       "NDCube\n",
+       "------\n",
+       "Dimensions: [1014. 1014.] pix\n",
+       "Physical Types of Axes: [('pos.eq.ra', 'pos.eq.dec'), ('pos.eq.ra', 'pos.eq.dec')]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ndc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:09.545870Z",
+     "start_time": "2021-04-16T15:10:09.542732Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "reference_files = {}\n",
+    "specwcs_filename = \"wfc3_ir_specwcs.asdf\"\n",
+    "wavelengthrange_filename = \"../WFC3_wavelengthrange.asdf\"\n",
+    "dist_ref_path = \"../WFC3IR_distortion.asdf\"\n",
+    "\n",
+    "reference_files['distortion'] = dist_ref_path\n",
+    "reference_files['wavelengthrange'] = wavelengthrange_filename\n",
+    "reference_files['specwcs'] = specwcs_filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:10.421689Z",
+     "start_time": "2021-04-16T15:10:09.933663Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dispersion_models import DISPXY_Model, DISPXY_Extension\n",
+    "asdf.get_config().add_extension(DISPXY_Extension())\n",
+    "\n",
+    "specwcs = asdf.open(reference_files['specwcs']).tree\n",
+    "displ = specwcs['displ']\n",
+    "dispx = specwcs['dispx']\n",
+    "dispy = specwcs['dispy']\n",
+    "invdispl = specwcs['invdispl']\n",
+    "invdispx = specwcs['invdispx']\n",
+    "invdispy = specwcs['invdispy']\n",
+    "orders = specwcs['order']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:11.080624Z",
+     "start_time": "2021-04-16T15:10:11.077125Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<DISPXY_Model(name='DISPXY_Model')>,\n",
+       " <DISPXY_Model(name='DISPXY_Model')>,\n",
+       " <DISPXY_Model(name='DISPXY_Model')>,\n",
+       " <DISPXY_Model(name='DISPXY_Model')>,\n",
+       " <DISPXY_Model(name='DISPXY_Model')>,\n",
+       " <DISPXY_Model(name='DISPXY_Model')>]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "invdispx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:12.014304Z",
+     "start_time": "2021-04-16T15:10:12.009025Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Create grism pipeline\n",
+    "\n",
+    "from gwcs import coordinate_frames as cf\n",
+    "from astropy import units as u\n",
+    "from transform_models import WFC3IRForwardGrismDispersion, WFC3IRBackwardGrismDispersion\n",
+    "\n",
+    "gdetector = cf.Frame2D(name='grism_detector', \n",
+    "                       axes_order=(0, 1),\n",
+    "                       unit=(u.pix, u.pix))\n",
+    "det2det = WFC3IRForwardGrismDispersion(orders,\n",
+    "                                        lmodels=displ,\n",
+    "                                        xmodels=invdispx,\n",
+    "                                        ymodels=dispy)\n",
+    "det2det.inverse = WFC3IRBackwardGrismDispersion(orders,\n",
+    "                                              lmodels=invdispl,\n",
+    "                                              xmodels=dispx,\n",
+    "                                              ymodels=dispy)\n",
+    "\n",
+    "grism_pipeline = [(gdetector, det2det)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:12.984001Z",
+     "start_time": "2021-04-16T15:10:12.980791Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from gwcs import WCS\n",
+    "\n",
+    "wcsobj = WCS(grism_pipeline)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:13.797306Z",
+     "start_time": "2021-04-16T15:10:13.793772Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     From      Transform\n",
+      "-------------- ---------\n",
+      "grism_detector      None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(wcsobj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:10:14.492174Z",
+     "start_time": "2021-04-16T15:10:14.487574Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(343.35376024540244, 104.13834046833674, 100, 100, 1)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "det2det.inverse.evaluate(100,100,2, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:30:23.272302Z",
+     "start_time": "2021-04-16T15:30:23.087332Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(204.26972147408998, 286.8536012589572, 160, 285, 1) (339.55872878229144, 302.99753117068565, 165, 300, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from extraction import extract_2d_spectrum\n",
+    "\n",
+    "sliced_data = extract_2d_spectrum(test[1].data, 160, 285, 165, 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:30:23.512410Z",
+     "start_time": "2021-04-16T15:30:23.509139Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(17, 136)"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sliced_data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-16T15:30:23.933346Z",
+     "start_time": "2021-04-16T15:30:23.840091Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7fae088cfb20>"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAABMCAYAAAB01uxdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAdhUlEQVR4nO2da6wtyVXff6t6P849d8YeD0YTZ8aKJ4qVyLFCQAgcgSKEiWITi8mHCNlBiqNYmi+JQhASGcsfUL4RJcpLvDQCYxMhm8QhYYRIeDhEfMIxJJFjbAzDKx5rzBjmee+55+zdVSsfqqp3de/u3r3fe1/qLx2d3fVc9ej/qrWqultUlYyMjIyM84M5tgAZGRkZGZshE3hGRkbGmSITeEZGRsaZIhN4RkZGxpkiE3hGRkbGmSITeEZGRsaZYisCF5F3icgXRORZEXlqV0JlZGRkZKyGbHoOXEQK4LeBvwE8B3waeJ+qfm534mVkZGRkdGGbFfg3AM+q6u+p6gz4OPDEbsTKyMjIyFiF0RZ5HwW+mFw/B3xjX4aJTPWC21tUmZGRkfGnD6/x0h+r6lc3w7ch8EEQkSeBJwEuuOQb5Z37rnKVQBDdRiLHlSWjDjGg7v6rK+P+xgFeR/LL+ok/bAvfhsC/BLw5uX4shNWgqk8DTwO8Th7eX0vXIeNM3PuHtHjnImG2xfXlW0oiqNPhZW5RV62OTcodkrepTNbNn3FYnND7o7Yh8E8DbxWRx/HE/V7g7+5EqqE4NyLuI4yuG7gZt21ZQ9BGin0yDCXRTWRZKkJADFKAWruTMgdUutz+ofVum26b8esqoy1+SFjGSZE3bEHgqlqKyD8CfgEogA+r6m/uTLJVOAXybhLYkLR98V3lpHFDbuhtSa0tfx9ZH4JEm8jk0o10rPrGshnWTL/NuA6Zy+eILt45ErFv5QNX1Z8Hfn5HsrRj30S9C/LZFYFt6Vo4CI4sh3ed2KPKcDZYd6x2ObbnMJc3Qadi2pCntiT+0+7JU1hlZ2SAJ51zJp6M3WDXc0Bk8bcB9n4KZSNsStxndIOJ8W2sNuNa4tL4NGwXUKc7L/NYSPtwX22q6kjm2Cn1XzpPVs2pVWUMxdB52jbX1q3rpDBkj2qjckMfrbEqPy0CX5e490TYh7wxV9W1L1lWlrvKj7oJhm6urrkJK8ZtrpD6TsvEeHXrl33gkySpfJvOmW3mWl/etrht53WXAmhTKn3pdqJIuvaoDjDup0Pgq8h7TRI5pdVRK/o2QE/JkjiUX3TLOqvx3seeRtdNucf27ASbnpxJ867aXE/TDyGvHW1iDrm/d5WmCzXyH7JZvAdCPx6B9xF2z0Qb3OGnQoKpvE1tbwR/gCdjFSTMl/Z39xyyD89pvLaRtaj/jnO38/5r1hXytKYvlu+FM4SYYYS85H5bReRruFJOZwUe0UG8g4j7kKS9ieY+datgTxCRJeKVDfc52srqS5uiLd+QNIdGv7I6EnY937vi7gNib6JrX2IXOA6Bd928+3ya7k8DnNZN3xNRGG1EtFNySm+O1AfaVkdjVdiZJi3vwKSi3H8kNghneD58LWIe2r6T3sRck7x7V967Iu9mHasGZR1i7CCXneZNHiuPTydKm/W8ygxuxp/jamiIzOu0K027jU95HRxpQ+xU0Heq6KRPr2wzRhsuaI7oA+85jpVO3Ebckulttn3qsIcYV3XqkLwpka7rNkjrH5JXFaz1fRT7Jc23qj0tbsz7Dq5xk8V+aoa34lDWXls9w+o+KbfLuohHEXvmXV/cXjGInIuQdHEiaqXCqZR1y/19kj5wMcsnBsJ1Rc5N8jEmiUsa2lwBLSkCGabZtn08dh2S7MrfRtZdZfWkb23J0H7YJdpW+4dcPbWdFtnmZESb7OtabgdAlOikiHyQctwR9tXugW1Q1ZqSqSmcVmtuQfotlSbp2+s7LIFLWG0n/tlqtZisGn1YQvImeVKpmdf/WK5r25V5xKqBa6tnnQmb5ndu+borTxq3Ks/QVeaQ1+y2pekLS8P3dHPtjKz6CHio+2QXro513rFT1dvYJE4vVp4gaUHriamWuG0V9L5cQztUpqoKxYqlf7i3qt5om5PiFuVF8za1OkJf1E6trOifgxK4iEGmU6QofIcUBhmN/G9jYFSACFrElXkga2PQwpO4jkx1HdOpsL57wlBTcEtIBkCU5QER8fUOgDTHskFuQ8pZKiMW1TQ6WtKpdORP5dhyvosqmoyBJGWrSO26E1033QYk0dVfXqCuzuwIdyA2vH8lPPasHfNNVBflqFbpl8pfZ77Wxqlt07W//1uLbBuTvjxNefvSrhrr5hj2yTFU+a+pxMW19GmHpSqryk/jnNbDVCty10jy1obwcOjAqSd157wV7RKij+XN2qs+8ApckMmkTtzTCWoExiO0KKAIJA2eoI2gRtCxQUVwE4MrBAy4sb+RdNWL/jQhunQeaks8yze/OEWS9yep8eXUbuKWchflNSeoV8at5XS2IU6INHA5b60ubcjVJptrD0/Lq+qQ9rStZNGQsxbW1lxt/G/mHYpkTLvTaBUfx12UTuUgDsw83FSFLPq9pW89gS/6pJZOk/7cYNyr382FR1d7WhYdVZY0XSijdb605O1WgC1yN9Ho49bFjapvo0nq7SPQVceq+05BdSjEvjLiuEmzjCaRa/IHSBmI2zoIJK7WgTpflrU1MhfV5AZtx2EJ3Bjk8hZMxuh4BOMR9vYEHRnsxQg79StrN/Gk7EaL/3YCWkB5Ibgx/m/iSdCNtXePp+rWaJl2kHVzUlfXDkzZSGfAFUliaS/DV95cJncolCak5aKNGElW2c0luTZloZbJ51mOl5i3QfBq8P3YRrSa1Bf/TMijINbHiRN/k0hUYpHskvhAJl3WSe3GT9pQhbvkeknhtPSLtpQZ08bxT9vD4n+V1lFT9LW+IdbRsVJO6vcWZeh7pXWMxIHpeyljTZk0okL5adlt/VRrQgvRdvYtYYXbVNiJ7Iv+rROjRPJeVX8qA3Qr39Z8LQudWp5EgYD/ndbVIketPdEtEpSolH5lTfXfVmQupfUrb2tRU3gyL0sojCf3FUr+sAReGPT1D+AuJ9hbY+zUMHtohB0LsweF8tKTc3nLk7WbKq4AN3XopUVGyuXrrrmcznj9xTVvunyFqbE8Mn2VB4vrWlUm0VwFihHHhcwxohQ4ihBvw11YiMM0Zk4R0t51U160t5m7UZXvgeKaPzN6pcpXiGOMZSIWi2DV4DDV71gHwG2Z8aDx8toGgzs1VdhYLEWYGfG/CbPIJcyWhsW8Mf21jnjVXfj4hpazCHMdYUOdLshpMVgVrtyUKzfFIty4MQCvL+5xaW6wmEqGCzPH4LjWCTduHMotcGqYmjmXZoZT4cXyAeZa8Gp5wavlLYw4Xje6ZiyWy2LG1MyZuxGv2Fs4lWqsoky+XYvr0pnwv8CFdlv17bhxRRXuNP0zlGqYWx9XOoNq+N/oV+sM1gmlLbgpC1QFYxzGKCJKEfrdquCcwVqDLX15YtzCIm9oIVXxo6OCOn+NE9R5DSZFUGhWwAYtlk5NFcQKciML67GhVKvp72RB9DHMhDxBQVeKwsWVJTUFGpXYksJrhsW6FcychZIuEpm68ibKeqG4UmKs15MuErqUz0KZNCI6CLwvvbFaS7tUTyhTbKMvrGLmzvfJzHlrfm6RuUOcQ2YlWIeUFpmXflU+n4NTpLB+Vd6Dk3kSUxoTIF1VoVLNOG+RLG7G+G7oJkk6NTUSj4jkbXA4TJXek7AupTXi0xdotQwvUE+u4hhL6RUEjolYxlIyBuaMsDjGsLTKvjQ3XLQu1cCKVCQyFodBgyJZyGZCmcn9SCFgtR4GMFZX9YNLfE1GHE4NM4pKacQ+jIrnws25dDc4DNeBwB8qrrg0N1U6L2fJGMu1jrnWcSjPK4ELM+dC5jgMY/FpxmIZGcdYLA+P7jINaW6bG2Za8KC9jUVCP5dBWZhK7gKHxVRKIiofrzR9313ZSaVkvGIz1ZyZq2HmRlgVSufZpVSvECJcKKt0BusMd+cTFBgbh4hiRBnFfk3SXZf+liqMw4jiVDxBJ4hhTsE5L5cNCsAYx6jwecsQpirVvK/miTXYm6Ji2CVPQ0xrBWsT603jhAnkaGVh8TgWVlkswuiC3BMSFQWx9bAIAWQOxgpqtCLwyipyUrcuYl0Nq2DJQqRO5Km11epCaqZjEZa2s628FJ6YZVlZpZZF1SdJ/YH4zdwgCsWNekIvRxT3LOIUc1P4FfrcQmH8qjxq/rL0q/IerCRwEfkw8B7gBVV9ewh7GPhp4C3AHwDfqaovrSoLa5GXXqW4mmAmY8ajgsnLyy4UOzULF0oRXCjTEa4AezHlegxXI/jSBX6CjBcToHaviC7CorkOflLGCROgqSukWYYKUi7Mer+qUBi7cB1uoGT1VO9DarMoruJinIhf0dXSswgX/Co7XpuQJyKSBVCtXNO5FRVCTCO0r+TTNGlcWsa0sIwLi2Eh86jlnRBGFBMsH09GBffKMaV6kpuVI0aF5atuXXFRzJkYy7TwCnLuCpwKI2Nrq1yAqbFBqQaLpLJMXE1BuabWbGAkDoNQhPGahrLSfF5+pVTD3XKCU2FibCVXrDteR4VgRBkbW8VH+aJFEa2GVM475YSrcsLION44ucvI2NrYjBOFH62RGF9qwdwVrQuW0hXcuPptfquYc6uY1fLeuIJZS7pJWLSkCrTq47S/gywOwapwZz5l5kZMTMmksMk4+f6c2aKyhuKcjXNmFEyG0hXMwlyIc2LRn76PAW7siLktqjJg+Z5I/9ugNNN5rUGJpogKVoEyluEMzom3wAo/ejaERUULYIPF5uYGvS4QK5irAjOH0T1hfMdbKeM7ipkro2tldOUwc8fonkWsw1yXfoUO8MLS0ALDVuAfAX4Q+Mkk7Cngk6r6AyLyVLj+pytLcg69dw/m82oTs7gagTEU45F3sRiDjsNmpvEnTbxfvAj+blNtYNqxUJ3iCERdzanKJy3JZmEIM7LsD0982FodYQxx6n16or58FZ/fjZrlsjBPU594+juWG/MZcIHgq7Qt6as6ot89VVYmTatVWL1dumhPqlAa7SdNZ3T5yHmhmMIvN0yDuE1IHye3kcVD4c4Z5vMCdd7d4KxgRo7r2ZjpuPQr8qJulYyMq258h2BQxoX15CvOx4eVcM1ltkTuC5KvZBUXnpJfENM4WVEDTEzJ1JSUzjAxJU4Nt4pZRaax3Ms0LNQ5NmXluotxFzKnEMdMR8zDsjS6hF4sH+AVe4sLM+fRyUtcyKxy4UX3X4oiCbvrpsx1VIVXbcQx1xHX6q2naC3eNjc8aO4BeBcawrWOueumQSbfhgfNPW4Ha6ug3ocFdaswuu6iNfSyu+Sum3JhZtyWGUYcE7zynWvBtY6xarjSKVZNzRV5W2aMpawsurmOeNVe1FyAFzLnweIeBcrL1te1KEO5kDljCcon5IsW5lwLZlp4SzNYi069OzFaeECoOyjakPfajblxI8bGcml8u67stErn0wp37JR7dsJr5ZQ/ub7NTTnixbuXzG5G3LszYfbyCDOHyatCcSOMrpTxHcGUBZM7BjNXimmBuVf0bsivJHBV/VUReUsj+AngW8LvjwL/gyEErqCzud+FLUt/CqUcISL+aKExSBGOCYbjg4h4Yh+HI4YjsyD2UTxuyPLOfkqC8akooUb49RX4Il9TCaSbeenJkThmzXKXiDeVqyFbWldK9k0SX2ycSbJE77I8lvMvlbnU/v48VbqixaJJNiFjXGmo9R9489I4KJwg1pd159YtXit0sTma1tWwXAAovNVVk615nchUC0/jmzdFWlfoACkcYhS1Bi1D4wpFClflEVH/sZ5o3VSKURuW1MKiUhWcq3esLQucFaRQJpOystBi/qaVI6IUIU1pvbvKT/W6HHG1SYgzoowKxygoy7jqLK2pfscy0nRt1lsXnAozW2CdUBitFHPMa8Nq17uO/Mo1tSzHhVcH0S3lFEobHngJdRSijEe2JntqpRZGl+Ssr7YXv9O4iCinC32yOGiykLcI88C5RbqYtrYCvzFgheLKYErhIqzApYTJa+pX5deO8V2HWGV0ZZHSYWYl5rqkD5v6wB9R1efD7y8DjwzJpM7hrm/827mA1gd6/IX/nzyBKeEg/eIpTqkO1y89Xp9epw+5pA/+dD3U0FVW82EVkWSlLst50ydH23aS4xvnqnQ9dcd0zTRVGSzaE17W1HtETRp5Y1ldz6YkR+HqvxsJjdTLo55u4UP0vkAtBB3JQvn2HQet1d8ie5s8DTna27a6Tn8KyfuCtQA1I6+sagq8txqfLp1zcTql7/3QxAKURRqfd7mOKPvYwSTmbbhMR3GTkmg9+nLm8VYLcYUmb04IukqBeRJWW2S0+a9bYIGyOa0Tv7aEcjRYoipQpuliO5L0cXPUxj4Rvwfk2xhcI6vGo+HHrg4UySK66hOtp28u8Kp+S2VMfOBS+n4uZhp84s77w516d0mpmLn1ZO0cchP+lxbm+yHwCqqqIt0qWUSeBJ4EuOAS1KGVtrJI1Ipi/Mo8/bKIBKI3ZrEbmxByfGKzqnzIo/VD06Z1+HbWrhG/4mlVEM3fXSTeKC9FUzl0PnW6QkG0oaY00rQdeTQl9560dWun2ffJT6cLRVOYyoLpRNLFzfPXS2fUm/KswoqnE1UIG0+KqOIKE6yF4OKrlMiAupppks2vpnutig9hfe1Mjydq444W6/u7shgl6cOQb7nNbfOpbu1Jk9TSLKnfrWtc4/0UytG2BUwLquOJsrhHKutUfIErlbI2rqNILfU3j3mqqSviZl1RIVZHOIPyFwUzD/PILk6kmBuLKZ0/mRJPpMzmxOOGlPsh8D8SkTep6vMi8iY6Xeygqk8DTwO8Th4OtvbCHEzJ3Dc87ZwQ1yD2Cm0DPuQR+jWegtPGY+jaUn7vu62Hfrospu16TLl3Rd3S5rZ64/nURnyv/EsKo6d/hyqSlDSKDgW4Th0D4rXRH3Hl2wxvLU8VseEMb3TvwbC+WOfpy7bx7npNQWKJpOi1vFIlnJJsLK9HzlZLMZWtd8HQLVL9xMuw9jTP0rdalLUMA+ZV11BWz0Es2qpFo+5K2IV8Vd5gbUo8D279k5YyDw/1zEs/F631hO0cWlrPkeEhnz5sSuDPAO8HfiD8/9nBOZuTpfHSofpLXezCZdJy6k7biMtu8W6F5mtU+16rmmrhDatb+6MGm77fpbkT2YjbSP41ZOn7aML6fdCRvvPrL7QqOF3zW5/afMXrUBdcF4EPVLpLH7BI5qa0kO5SCV0uxKZ8TYtxWZDldM24BDp08dFXTuqGHJJvU4XWh3RFHcsrOuRMX6OQ5Be3eICnWgxUT2UmT2S6QHLpE5nbngMXkY/hNyzfKCLPAd+PJ+7/ICIfAP4Q+M5V5QxCy03V+1X2tvcmr4u2cpthJ/JhhN6XW/WhWhE08hvTTeyr0DexGib0Ug0tjyUPr3eDuGb/dL0IrA8xTyP9EAW05H6rydZGiMmG2FJhifU60A24TIypT6rnHupQKEPqaE217gKkZ0+oFW3yDi27D+mCI83bp6zT67iojGSdEnNcZTfeh0L6PpQeDDmF8r6OqHeuyttTqP/fal6vtzI6F+z1012bvq6zJd86cp3kp78ihr7OdpO36a1rfUV3TVudDbTNk00/P9eJTSy55ljvWqYu7OqtovtE3/1Xs54S5VstqtKd6tS1PGwunsyTmKswaCUesY4CGPKe5x2g67Nim3y3cRd17wJHI+5Nv6izbVldedb9glHq7mkomn18fq7phpFNFf6+0XztcXp4oQ8d1lHn65lXhfXVsSZa3V+1BD2kPeBVu8cl8KY/vApve5tNOI854CYZ+rXoTsQ5M/STVltYDEO+f7iUZtNPwPWtSk/FTTQEpyrriX7ournaU3R5w7wNh/60XnP/at39rLb0Q8LWsfrX+VDIUtaefuwqY1sXyt4x1CRr67jOpP2NHvSF+2adu0i3LMj65YlZ/4Zqpm/Lv853QPs2DA+IVZbJXtwPa9Z1cCtlqOto198OPfI3O9PPmMXr9TBgpb+LPFt8pKMNxyfwiHV8a1t+XHafH0YdrBy8IOtXsI8bZUj/DVEC26BrtdfTn0PIUdPV1p6VTqc8fX015GPVzXS7Jt9dYJt9qyEr4BXzvnnfrXUf7gCDOWXHH6o+HQKP2GSTZGhHHGBz9BS/mt32gdXaBD/m6imOSVe/bdqfbW1yJ7ghto7f/FSxratlyAmYUxy7ZI71KYxOTlj1ybS+478Bp0fgEfvY7T4hoj8k2iZQc1O4k9z3jUMqjyOb+SvRdkOvOxd3cbR2XexDuRxbYXVZBSc2h06XwCP6NNC+/Ju7HKQTVwZ95J4xDDtTeG3zbs25uFDMp0U0Z4kVfb/xfTJ4b+2cfOCboOsUyynhPj3XnrHAOjfyLq2bPiuquam3qzqOiU3bdDILkj2s3s+bwKFbS50Ssa8auFW+sJhmnbqy0jhJ7INMusrcZV2nQoKnIsda2OGKu4nzJ/AurOqMdV82tM8n0IYM8LraexfavmvHPCuHw2HX47jLevI88DiiX/z+JfCMjHND0922K2I4BMFkBX8UyCEfNBCRrwB3gT8+WKX7wRs5/zbA/dGO3IbTQG7DfvHnVPWrm4EHJXAAEfl1Vf36g1a6Y9wPbYD7ox25DaeB3IbjINs6GRkZGWeKTOAZGRkZZ4pjEPjTR6hz17gf2gD3RztyG04DuQ1HwMF94BkZGRkZu0F2oWRkZGScKQ5K4CLyLhH5gog8KyJPHbLuTSEibxaRXxGRz4nIb4rId4fwh0Xkl0Tkd8L/Nxxb1lUQkUJE/reI/Fy4flxEPhXG46dFZHJsGfsgIg+JyCdE5LdE5PMi8tfObRxE5HvCPPqsiHxMRC7OYRxE5MMi8oKIfDYJa+178fh3oT2fEZGvO57kC3S04V+E+fQZEfnPIvJQEvfB0IYviMjfPIrQK3AwAheRAvgh4N3A24D3icjbDlX/FiiB71XVtwHvAP5hkPsp4JOq+lbgk+H61PHdwOeT638O/GtV/QvAS8AHjiLVcPxb4L+p6l8CvgbflrMZBxF5FPjHwNer6tuBAngv5zEOHwHe1Qjr6vt3A28Nf08CP3IgGVfhIyy34ZeAt6vqXwF+G/ggQLjH3wv85ZDnhwOHnRQOuQL/BuBZVf09VZ0BHweeOGD9G0FVn1fV/xV+v4YnjUfxsn80JPso8LePIuBAiMhjwN8CfixcC/CtwCdCkpNug4i8HvjrwI8DqOpMVV/mzMYB//TzLREZAZfA85zBOKjqrwIvNoK7+v4J4CfV49eAh0TkTQcRtAdtbVDVX1TVMlz+GvBY+P0E8HFVvVHV3weexXPYSeGQBP4o8MXk+rkQdjYQkbcAXwt8CnhEVZ8PUV8GHjmWXAPxb4DvA+Izz18FvJxM3lMfj8eBrwA/EdxAPyYitzmjcVDVLwH/Evh/eOJ+BfgNzmscUnT1/bne6/8A+K/h91m0IW9iDoSIPAD8J+CfqOqraZz6ozwne5xHRN4DvKCqv3FsWbbACPg64EdU9Wvxr2SouUvOYBzegF/ZPQ78WeA2yyb9WeLU+34VRORDeHfpTx1blnVwSAL/EvDm5PqxEHbyEJExnrx/SlV/JgT/UTQLw/8XjiXfAHwT8B0i8gd419W34v3JDwVTHk5/PJ4DnlPVT4XrT+AJ/ZzG4duA31fVr6jqHPgZ/Nic0zik6Or7s7rXReTvA+8BvksX56rPog2HJPBPA28NO+4T/AbBMwesfyMEX/GPA59X1X+VRD0DvD/8fj/ws4eWbShU9YOq+piqvgXf7/9dVb8L+BXg74Rkp96GLwNfFJG/GILeCXyOMxoHvOvkHSJyGeZVbMPZjEMDXX3/DPD3wmmUdwCvJK6Wk4KIvAvvWvwOVb1Kop4B3isiUxF5HL8h+z+PIWMvVPVgf8C343d6fxf40CHr3kLmb8abhp8B/k/4+3a8D/mTwO8Avww8fGxZB7bnW4CfC7//PH5SPgv8R2B6bPlWyP5XgV8PY/FfgDec2zgA/wz4LeCzwL8HpucwDsDH8H77Od4a+kBX3wOCP3H2u8D/xZ+6OdU2PIv3dcd7+0eT9B8KbfgC8O5jy9/2l5/EzMjIyDhT5E3MjIyMjDNFJvCMjIyMM0Um8IyMjIwzRSbwjIyMjDNFJvCMjIyMM0Um8IyMjIwzRSbwjIyMjDNFJvCMjIyMM8X/BwL0sly10PtIAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(sliced_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/HST/WFC3_model_testing.ipynb
+++ b/HST/WFC3_model_testing.ipynb
@@ -159,6 +159,13 @@
     "# Using the output of the previous cell as input \n",
     "det2det.evaluate(919.0, 800.584437342649, 917.0, 800.0, order)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/HST/extraction.py
+++ b/HST/extraction.py
@@ -1,0 +1,42 @@
+import ndcube
+import numpy as np
+from astropy.io import fits
+import asdf
+
+from dispersion_models import DISPXY_Model, DISPXY_Extension
+from transform_models import WFC3IRForwardGrismDispersion, WFC3IRBackwardGrismDispersion
+
+def extract_2d_spectrum(data, ll_x, ll_y, ur_x, ur_y, ll_l = 1.0,
+                      ur_l = 3.0, order = 1, specwcs_ref = "wfc3_ir_specwcs.asdf"):
+    """
+    Function to do a simple box cutout around a 2D spectrum.
+
+    The input lower and upper x and y bounds are pixel coordinates from the
+    direct image. The upper and lower wavelength bounds are in microns.
+    """
+    asdf.get_config().add_extension(DISPXY_Extension())
+    specwcs = asdf.open(specwcs_ref).tree
+    displ = specwcs['displ']
+    dispx = specwcs['dispx']
+    dispy = specwcs['dispy']
+    invdispl = specwcs['invdispl']
+    invdispx = specwcs['invdispx']
+    invdispy = specwcs['invdispy']
+    orders = specwcs['order']
+
+    det2det = WFC3IRForwardGrismDispersion(orders,
+                                           lmodels=displ,
+                                           xmodels=invdispx,
+                                           ymodels=dispy)
+    det2det.inverse = WFC3IRBackwardGrismDispersion(orders,
+                                                    lmodels=invdispl,
+                                                    xmodels=dispx,
+                                                    ymodels=dispy)
+
+    ll = det2det.inverse.evaluate(ll_x, ll_y, ll_l, order)
+    ur = det2det.inverse.evaluate(ur_x, ur_y, ur_l, order)
+
+    print(ll, ur)
+
+    return data[int(ll[1]):int(ur[1])+1, int(ll[0]):int(ur[0])+1]
+

--- a/HST/extraction.py
+++ b/HST/extraction.py
@@ -6,13 +6,18 @@ import asdf
 from dispersion_models import DISPXY_Model, DISPXY_Extension
 from transform_models import WFC3IRForwardGrismDispersion, WFC3IRBackwardGrismDispersion
 
-def extract_2d_spectrum(data, ll_x, ll_y, ur_x, ur_y, ll_l = 1.0,
-                      ur_l = 3.0, order = 1, specwcs_ref = "wfc3_ir_specwcs.asdf"):
+def extract_2d_spectrum(data, ll_x, ll_y, ur_x, ur_y, ll_l = 1.1,
+                      ur_l = 1.7, order = 1, specwcs_ref = "wfc3_ir_specwcs.asdf"):
     """
     Function to do a simple box cutout around a 2D spectrum.
 
     The input lower and upper x and y bounds are pixel coordinates from the
     direct image. The upper and lower wavelength bounds are in microns.
+
+    TODO: Change this to take grism as input instead of lower and upper wavelengths
+    and specwcs reference file, with default wavelength range based on grism.
+    Currently assumes the G141 reference file and wavelength ranged that I've been
+    working with.
     """
     asdf.get_config().add_extension(DISPXY_Extension())
     specwcs = asdf.open(specwcs_ref).tree


### PR DESCRIPTION
For now, this takes as input the upper and lower x and y bounds, and has the default wavelength range set for G141. I'm also considering whether/how to use the JWST GrismObject class as part of this (see [source code here](https://github.com/spacetelescope/jwst/blob/085801ffaed3df70d4013c3936f0bcde74646eb7/jwst/transforms/models.py#L46)). The SpectrumExtraction notebook uses ib6o23rsq_flt.fits, which can be downloaded from https://github.com/npirzkal/aXe_WFC3_Cookbook/tree/main/cookbook_data/G141.